### PR TITLE
Make the green line which marks the start of the load a bit more obvious.

### DIFF
--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -577,7 +577,7 @@ class ACISThermalCheck(object):
                                       color='y', linewidth=2.0)
             # Add a vertical line to mark the start of the load
             plots[msid]['ax'].axvline(load_start, linestyle=':', color='g',
-                                      linewidth=1.0)
+                                      linewidth=2.0)
             filename = self.MSIDs[self.name].lower() + '.png'
             outfile = os.path.join(outdir, filename)
             self.logger.info('Writing plot file %s' % outfile)
@@ -600,7 +600,7 @@ class ACISThermalCheck(object):
             figsize=(7.5, 3.5))
         # Add a vertical line to mark the start time of the load
         plots['pow_sim']['ax'].axvline(load_start, linestyle=':', color='g',
-                                       linewidth=1.0)
+                                       linewidth=2.0)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
         w1, h1 = plots[self.name]['fig'].get_size_inches()

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -576,7 +576,7 @@ class ACISThermalCheck(object):
             plots[msid]['ax'].axhline(self.yellow[msid] - self.margin[msid], linestyle='--',
                                       color='y', linewidth=2.0)
             # Add a vertical line to mark the start of the load
-            plots[msid]['ax'].axvline(load_start, linestyle=':', color='g',
+            plots[msid]['ax'].axvline(load_start, linestyle='-', color='g',
                                       linewidth=2.0)
             filename = self.MSIDs[self.name].lower() + '.png'
             outfile = os.path.join(outdir, filename)
@@ -599,7 +599,7 @@ class ACISThermalCheck(object):
             ylim2=(-105000, 105000),
             figsize=(7.5, 3.5))
         # Add a vertical line to mark the start time of the load
-        plots['pow_sim']['ax'].axvline(load_start, linestyle=':', color='g',
+        plots['pow_sim']['ax'].axvline(load_start, linestyle='-', color='g',
                                        linewidth=2.0)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.


### PR DESCRIPTION
I proposed that the start of the load be marked with a green vertical line, without realizing that it was already there! 

I first saw it in the code when I tried to add it, and noticed that it was very thin and had the same form as the grid markers, so this PR makes it a bit wider and makes it solid. 

example image for the AUG0816 load:

![1deamzt](https://cloud.githubusercontent.com/assets/1914976/17338957/b1dd8868-58b7-11e6-825e-ffe4abcadacb.png)
