### PR TITLE
Allow use of sqlite3 command states and timelines database + Py3 compatibility

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -8,3 +8,11 @@ from acis_thermal_check.utils import \
 from acis_thermal_check.dea_check import dea_check
 from acis_thermal_check.dpa_check import dpa_check
 from acis_thermal_check.psmc_check import psmc_check
+
+
+def test(*args, **kwargs):
+    '''
+    Run py.test unit tests.
+    '''
+    import testr
+    return testr.test(*args, **kwargs)

--- a/acis_thermal_check/dea_check/__init__.py
+++ b/acis_thermal_check/dea_check/__init__.py
@@ -1,1 +1,1 @@
-from dea_check import dea_check
+from .dea_check import dea_check

--- a/acis_thermal_check/dea_check/dea_check.py
+++ b/acis_thermal_check/dea_check/dea_check.py
@@ -10,6 +10,8 @@ DEA temperature 1DEAMZT.  It also generates DEA model validation
 plots comparing predicted values to telemetry for the previous three
 weeks.
 """
+from __future__ import print_function
+
 # Matplotlib setup                                                                                                                                             
 # Use Agg backend for command-line (non-interactive) operation                                                                                                 
 import matplotlib
@@ -64,11 +66,11 @@ def main():
     opt, args = get_options("1DEAMZT", "dea", script_path)
     try:
         dea_check.driver(opt)
-    except Exception, msg:
+    except Exception as msg:
         if opt.traceback:
             raise
         else:
-            print "ERROR:", msg
+            print("ERROR:", msg)
             sys.exit(1)
 
 if __name__ == '__main__':

--- a/acis_thermal_check/dpa_check/__init__.py
+++ b/acis_thermal_check/dpa_check/__init__.py
@@ -1,1 +1,1 @@
-from dpa_check import dpa_check
+from .dpa_check import dpa_check

--- a/acis_thermal_check/dpa_check/dpa_check.py
+++ b/acis_thermal_check/dpa_check/dpa_check.py
@@ -10,6 +10,8 @@ DPA temperature 1DPAMZT.  It also generates DPA model validation
 plots comparing predicted values to telemetry for the previous three
 weeks.
 """
+from __future__ import print_function
+
 # Matplotlib setup                                                                                                                                              
 # Use Agg backend for command-line (non-interactive) operation                                                                                                   
 import matplotlib
@@ -76,11 +78,11 @@ def main():
     opt, args = get_options("1DPAMZT", "dpa", script_path)
     try:
         dpa_check.driver(opt)
-    except Exception, msg:
+    except Exception as msg:
         if opt.traceback:
             raise
         else:
-            print "ERROR:", msg
+            print("ERROR:", msg)
             sys.exit(1)
 
 if __name__ == '__main__':

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # Matplotlib setup                                                             
 # Use Agg backend for command-line (non-interactive) operation                                                
 import matplotlib
@@ -10,7 +12,6 @@ import time
 import pickle
 import numpy as np
 import Ska.DBI
-import Ska.Table
 import Ska.Numpy
 from Chandra.Time import DateTime
 import Chandra.cmd_states as cmd_states
@@ -565,8 +566,8 @@ class ACISThermalCheck(object):
         import django.conf
         try:
             django.conf.settings.configure()
-        except RuntimeError, msg:
-            print msg
+        except RuntimeError as msg:
+            print(msg)
 
         outfile = os.path.join(opt.outdir, 'index.rst')
         self.logger.info('Writing report file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -578,32 +578,26 @@ class ACISThermalCheck(object):
         """
         Make output text (in ReST format) in opt.outdir.
         """
-        # Django setup (used for template rendering)
-        import django.template
-        import django.conf
-        try:
-            django.conf.settings.configure()
-        except RuntimeError as msg:
-            print(msg)
+        import jinja2
 
         outfile = os.path.join(opt.outdir, 'index.rst')
         self.logger.info('Writing report file %s' % outfile)
-        django_context = django.template.Context(
-            {'opt': opt,
+        context = {
+             'opt': opt,
              'plots': plots,
              'viols': viols,
              'valid_viols': valid_viols,
              'proc': proc,
              'plots_validation': plots_validation,
-             })
+             }
         index_template_file = ('index_template.rst'
                                if opt.oflsdir else
                                'index_template_val_only.rst')
         index_template = open(os.path.join(TASK_DATA, 'acis_thermal_check', 
                                            'templates', index_template_file)).read()
         index_template = re.sub(r' %}\n', ' %}', index_template)
-        template = django.template.Template(index_template)
-        open(outfile, 'w').write(template.render(django_context))
+        template = jinja2.Template(index_template)
+        open(outfile, 'w').write(template.render(**context))
 
     def get_states(self, datestart, datestop, db):
         """Get states exactly covering date range

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -200,7 +200,7 @@ class ACISThermalCheck(object):
 
 
     def set_initial_state(self, tlm, db, t_msid):
-        state0 = cmd_states.get_state0(tlm['date'][-5], db,
+        state0 = cmd_states.get_state0(DateTime(tlm['date'][-5]).date, db,
                                            datepar='datestart')
         ok = ((tlm['date'] >= state0['tstart'] - 700) &
               (tlm['date'] <= state0['tstart'] + 700))

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -68,9 +68,11 @@ class ACISThermalCheck(object):
 
         self.logger.info('Command line options:\n%s\n' % pformat(opt.__dict__))
 
-        # Connect to database (NEED TO USE aca_read)
-        self.logger.info('Connecting to database to get cmd_states')
-        db = Ska.DBI.DBI(dbi='sybase', server='sybase', user='aca_read',
+        # Connect to database (NEED TO USE aca_read for sybase; user is ignored for sqlite)
+        server = ('sybase' if opt.cmd_states_db == 'sybase' else
+                  os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3'))
+        self.logger.info('Connecting to {} to get cmd_states'.format(server))
+        db = Ska.DBI.DBI(dbi=opt.cmd_states_db, server=server, user='aca_read',
                          database='aca')
 
         tnow = DateTime(opt.run_start).secs

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -536,7 +536,7 @@ class ACISThermalCheck(object):
         if opt.run_start:
             filename = os.path.join(outdir, 'validation_data.pkl')
             self.logger.info('Writing validation data %s' % filename)
-            f = open(filename, 'w')
+            f = open(filename, 'wb')
             pickle.dump({'pred': pred, 'tlm': tlm}, f, protocol=-1)
             f.close()
 

--- a/acis_thermal_check/psmc_check/__init__.py
+++ b/acis_thermal_check/psmc_check/__init__.py
@@ -1,1 +1,1 @@
-from psmc_check import psmc_check
+from .psmc_check import psmc_check

--- a/acis_thermal_check/psmc_check/psmc_check.py
+++ b/acis_thermal_check/psmc_check/psmc_check.py
@@ -10,6 +10,7 @@ PSMC temperature 1PDEAAT.  It also generates PSMC model validation
 plots comparing predicted values to telemetry for the previous three
 weeks.
 """
+from __future__ import print_function
 
 # Matplotlib setup                                                                                                                                              
 # Use Agg backend for command-line (non-interactive) operation                                                                                                   
@@ -111,11 +112,11 @@ def main():
                             [("dh_heater", dhh_opt)])
     try:
         psmc_check.driver(opt)
-    except Exception, msg:
+    except Exception as msg:
         if opt.traceback:
             raise
         else:
-            print "ERROR:", msg
+            print("ERROR:", msg)
             sys.exit(1)
 
 if __name__ == '__main__':

--- a/acis_thermal_check/psmc_check/psmc_check.py
+++ b/acis_thermal_check/psmc_check/psmc_check.py
@@ -19,7 +19,7 @@ matplotlib.use('Agg')
 
 import logging
 import Chandra.cmd_states as cmd_states
-import Ska.Table
+from astropy.io import ascii
 import Ska.Numpy
 import Chandra.Time
 import numpy as np
@@ -88,7 +88,7 @@ class PSMCModelCheck(ACISThermalCheck):
             # htrbfn = '/home/edgar/acis/thermal_models/dhheater_history/dahtbon_history.rdb'                     
             htrbfn = 'dahtbon_history.rdb'
             logger.info('Reading file of dahtrb commands from file %s' % htrbfn)
-            htrb = Ska.Table.read_ascii_table(htrbfn,headerrow=2,headertype='rdb')
+            htrb = ascii.read(htrbfn, format='rdb')
             dh_heater_times = Chandra.Time.date2secs(htrb['time'])
             dh_heater = htrb['dahtbon'].astype(bool)
         return self.calc_model(opt.model_spec, states, tstart, tstop, T_psmc=start_msid,

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -16,7 +16,7 @@ Summary
 ====================  =============================================
 Date start            {{proc.datestart}}
 Date stop             {{proc.datestop}}
-{{proc.msid}} status        {%if viols.default%}:red:`NOT OK`{% else %}OK{% endif%} (Planning Limit = {{proc.msid_limit|floatformat:1}} C)
+{{proc.msid}} status        {%if viols.default%}:red:`NOT OK`{% else %}OK{% endif%} (Planning Limit = {{"%.1f"|format(proc.msid_limit)}} C)
 {% if opt.loaddir %}
 Load directory        {{opt.loaddir}}
 {% endif %}
@@ -33,7 +33,7 @@ States                `<states.dat>`_
 Date start             Date stop              Max temperature
 =====================  =====================  ==================
 {% for viol in viols.default %}
-{{viol.datestart}}  {{viol.datestop}}  {{viol.maxtemp|floatformat:2}}
+{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}
 {% endfor %}
 =====================  =====================  ==================
 {% else %}
@@ -71,7 +71,7 @@ Validation Violations
    :widths: 15, 10, 10, 10
 
 {% for viol in valid_viols %}
-   {{viol.msid}},{{viol.quant}},{{viol.value}},{{viol.limit|floatformat:2}}
+   {{viol.msid}},{{viol.quant}},{{viol.value}},{{"%.2f"|format(viol.limit)}}
 {% endfor%}
 
 {% else %}
@@ -83,11 +83,11 @@ No Validation Violations
 {{ plot.msid }}
 -----------------------
 
-{% ifequal proc.hist_limit|length 2 %}
+{% if proc.hist_limit|length == 2 %}
 Note: {{proc.short_msid}} residual histograms include points where {{proc.msid}} > {{proc.hist_limit.0}} degC in blue and points where {{proc.msid}} > {{proc.hist_limit.1}} degC in red.
 {% else %}
 Note: {{proc.short_msid}} residual histograms include only points where {{proc.msid}} > {{proc.hist_limit.0}} degC.
-{% endifequal %}
+{% endif %}
 
 Red = telemetry, blue = model
 

--- a/acis_thermal_check/templates/index_template_val_only.rst
+++ b/acis_thermal_check/templates/index_template_val_only.rst
@@ -50,7 +50,7 @@ Validation Violations
    :widths: 15, 10, 10, 10
 
 {% for viol in valid_viols %}
-   {{viol.msid}},{{viol.quant}},{{viol.value}},{{viol.limit|floatformat:2}}
+   {{viol.msid}},{{viol.quant}},{{viol.value}},{{"%.2f"|format(viol.limit)}}
 {% endfor%}
 
 {% else %}
@@ -62,11 +62,11 @@ No Validation Violations
 {{ plot.msid }}
 -----------------------
 
-{% ifequal proc.hist_limit|length 2 %}
+{% if proc.hist_limit|length == 2 %}
 Note: {{proc.short_msid}} residual histograms include points where {{proc.msid}} > {{proc.hist_limit.0}} degC in blue and points where {{proc.msid}} > {{proc.hist_limit.1}} degC in red.
 {% else %}
 Note: {{proc.short_msid}} residual histograms include only points where {{proc.msid}} > {{proc.hist_limit.0}} degC.
-{% endifequal %}
+{% endif %}
 
 Red = telemetry, blue = model
 

--- a/acis_thermal_check/tests/utils.py
+++ b/acis_thermal_check/tests/utils.py
@@ -13,7 +13,7 @@ class TestOpts(object):
     def __init__(self, short_msid, run_start, outdir, oflsdir=None, 
                  days=21.0, ccd_count=6, fep_count=6, vid_board=1,
                  clocking=1, simpos=75616.0, pitch=150.0, T_init=None,
-                 dh_heater=0):
+                 dh_heater=0, cmd_states_db='sybase'):
         self.run_start = run_start
         self.outdir = outdir
         self.oflsdir = oflsdir
@@ -24,6 +24,7 @@ class TestOpts(object):
         self.clocking = clocking
         self.simpos = simpos
         self.pitch = pitch
+        self.cmd_states_db = cmd_states_db
         setattr(self, "T_%s" % short_msid, T_init)
         self.dh_heater = dh_heater
         self.traceback = True

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -152,6 +152,9 @@ def get_options(msid, short_msid, script_path, opts=None):
     parser.add_option("--T-%s" % short_msid,
                       type='float',
                       help="Starting %s temperature (degC)" % msid)
+    parser.add_option("--cmd-states-db",
+                      default="sqlite",
+                      help="Commanded states database server (sybase|sqlite)" % msid)
     parser.add_option("--version",
                       action='store_true',
                       help="Print version")
@@ -160,5 +163,8 @@ def get_options(msid, short_msid, script_path, opts=None):
             parser.add_option("--%s" % opt_name, **opt)
 
     opt, args = parser.parse_args()
-    return opt, args
 
+    if opt.cmd_states_db not in ('sybase', 'sqlite'):
+        raise ValueError('--cmd-states-db must be one of "sybase" or "sqlite"')
+
+    return opt, args

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -153,7 +153,7 @@ def get_options(msid, short_msid, script_path, opts=None):
                       type='float',
                       help="Starting %s temperature (degC)" % msid)
     parser.add_option("--cmd-states-db",
-                      default="sqlite",
+                      default="sybase",
                       help="Commanded states database server (sybase|sqlite)")
     parser.add_option("--version",
                       action='store_true',

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -154,7 +154,7 @@ def get_options(msid, short_msid, script_path, opts=None):
                       help="Starting %s temperature (degC)" % msid)
     parser.add_option("--cmd-states-db",
                       default="sqlite",
-                      help="Commanded states database server (sybase|sqlite)" % msid)
+                      help="Commanded states database server (sybase|sqlite)")
     parser.add_option("--version",
                       action='store_true',
                       help="Print version")


### PR DESCRIPTION
There is no (useful) support in Python 3 for Sybase, so in order to migrate to a code base that works on Python 3 it is necessary to use a different database backend.  This PR provides a Py2/Py3 compatible code which can optionally use an sqlite3 database file that has the relevant tables required for doing ACIS thermal checks.  This is currently `/proj/sot/ska/data/cmd_states/cmd_states.db3` but note that it is not yet being automatically updated.

This is a WIP.  In this version the default is to choose `sqlite`.  This is for convenience in testing but that would not be the case at promotion time.

This has been tested on Py2 and gives identical results to current master (where the test was run with sqlite and master was run with Sybase).  There is still at least one outstanding dependency in the Ska Py3 stack so that is not yet tested.