### PR TITLE
Only report thermal violations which occur after a load starts

### DIFF
--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -456,7 +456,8 @@ class ACISThermalCheck(object):
             plan_limit = self.yellow[msid] - self.margin[msid]
             # The NumPy black magic of the next two lines is to figure 
             # out which time periods have planning limit violations and 
-            # to find the bounding indexes of these times. 
+            # to find the bounding indexes of these times. This will also
+            # find violations which happen for one discrete time value also.
             bad = np.concatenate(([False], temp >= plan_limit, [False]))
             changes = np.flatnonzero(bad[1:] != bad[:-1]).reshape(-1, 2)
             # Now go through the periods where the temperature violates

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -465,7 +465,9 @@ class ACISThermalCheck(object):
             for change in changes:
                 # Only report violations which occur after the load being
                 # reviewed starts.
-                if times[change[0]] > tstart:
+                in_load = times[change[0]] > tstart or \
+                          (times[change[0]] < tstart < times[change[1]])
+                if in_load:
                     viol = {'datestart': DateTime(times[change[0]]).date,
                             'datestop': DateTime(times[change[1] - 1]).date,
                             'maxtemp': temp[change[0]:change[1]].max()}

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -320,7 +320,7 @@ class ACISThermalCheck(object):
         plt.rc("ytick", labelsize=10)
         temps = {self.name: model.comp[self.msid].mvals}
         # make_prediction_plots runs the validation of the model against previous telemetry
-        plots = self.make_prediction_plots(opt.outdir, states, model.times, temps, tstart)
+        plots = self.make_prediction_plots(opt.outdir, states, model.times, temps, bs_cmds[0]['time'])
         # make_prediction_viols determines the violations and prints them out
         viols = self.make_prediction_viols(model.times, temps, tstart)
         # write_states writes the commanded states to states.dat


### PR DESCRIPTION
This PR changes the reporting of thermal violations so that they only are reported for the period of a thermal model prediction that corresponds to the time period of the load being reviewed. 

The logic here checks for violations which occur completely after a load start or which have begun before a load start but are still happening at the time of the load start. 

I've tested this against the APR1017 load to make sure a violation is still reported there as before, since it happens during the load, but can also verify that it doesn't report it for the next load, APR1717. 

I also made a change to insure that the green dashed vertical line which shows up on the prediction plots actually refers to the start of the load instead of `tstart`, which could change if one sets the `--run-start` runtime parameter.

I have to fix something related to the web page template before this can go in, but otherwise it's ok for review.