### PR TITLE
Grab ACIS thermal limits from web table

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -3,7 +3,8 @@ __version__ = "1.2.0"
 from acis_thermal_check.main import \
     ACISThermalCheck
 from acis_thermal_check.utils import \
-    calc_off_nom_rolls, get_options
+    calc_off_nom_rolls, get_options, \
+    get_acis_limits
 
 def test(*args, **kwargs):
     '''

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -222,3 +222,23 @@ def get_options(msid, name, model_path, opts=None):
         raise ValueError('--cmd-states-db must be one of "sybase" or "sqlite"')
 
     return args
+
+def get_acis_limits(msid):
+
+    import requests
+
+    yellow_hi = None
+    red_hi = None
+
+    url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+
+    u = requests.get(url)
+
+    for line in u.text.split("\n"):
+        words = line.strip().split("\t")
+        if len(words) > 1 and words[0] == msid.upper():
+            yellow_hi = float(words[3])
+            red_hi = float(words[5])
+            break
+
+    return yellow_hi, red_hi


### PR DESCRIPTION
This PR adds a simple function to parse the ACIS limits table on the web given a MSID name and returns the yellow hi and red hi limits. It is designed to be called from any of the individual ACIS thermal checking packages so that they can handle how to report limits individually. 

For example:
```python
from acis_thermal_check import get_acis_limits
yellow_hi, red_hi = get_acis_limits("1deamzt")
```
