### PR TITLE
Add parsing of MIT BEP/FEP limits file

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.1-dev0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -264,14 +264,15 @@ def get_acis_limits(msid):
     if msid.startswith("tmp_"):
         url = "http://cxc.cfa.harvard.edu/acis/PMON/pmon_limits.txt"
         cols = (5, 6)
+        msid = "ADC_"+msid.upper()
     else:
-        url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+        url = "http://cxc.cfa.harvard.edu/acis/Thermal/MSID_Limits.txt"
         cols = (3, 5)
 
     u = requests.get(url)
 
     for line in u.text.split("\n"):
-        words = line.strip().split("\t")
+        words = line.strip().split()
         if len(words) > 1 and words[0] == msid.upper():
             yellow_hi = float(words[cols[0]])
             red_hi = float(words[cols[1]])

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -261,17 +261,28 @@ def get_acis_limits(msid):
     yellow_hi = None
     red_hi = None
 
+    pmon_file = "PMON/pmon_limits.txt"
+    eng_file = "Thermal/MSID_Limits.txt"
+    file_root = "/proj/web-cxc-dmz/htdocs/acis/"
+
     if msid.startswith("tmp_"):
-        url = "http://cxc.cfa.harvard.edu/acis/PMON/pmon_limits.txt"
+        limits_file = pmon_file
         cols = (5, 6)
         msid = "ADC_"+msid.upper()
     else:
-        url = "http://cxc.cfa.harvard.edu/acis/Thermal/MSID_Limits.txt"
+        limits_file = eng_file
         cols = (3, 5)
 
-    u = requests.get(url)
+    if os.path.exists(file_root):
+        f = open(os.path.join(file_root, limits_file), "r")
+        lines = f.readlines()
+        f.close()
+    else:
+        url = "http://cxc.cfa.harvard.edu/acis/"+limits_file
+        u = requests.get(url)
+        lines = u.text.split("\n")
 
-    for line in u.text.split("\n"):
+    for line in lines:
         words = line.strip().split()
         if len(words) > 1 and words[0] == msid.upper():
             yellow_hi = float(words[cols[0]])

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -274,10 +274,12 @@ def get_acis_limits(msid):
         cols = (3, 5)
 
     if os.path.exists(file_root):
+        mylog.info("Obtaining limits from local file.")
         f = open(os.path.join(file_root, limits_file), "r")
         lines = f.readlines()
         f.close()
     else:
+        mylog.info("Obtaining limits from remote file.")
         url = "http://cxc.cfa.harvard.edu/acis/"+limits_file
         u = requests.get(url)
         lines = u.text.split("\n")

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -261,15 +261,20 @@ def get_acis_limits(msid):
     yellow_hi = None
     red_hi = None
 
-    url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+    if msid.startswith("tmp_"):
+        url = "http://cxc.cfa.harvard.edu/acis/PMON/pmon_limits.txt"
+        cols = (5, 6)
+    else:
+        url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+        cols = (3, 5)
 
     u = requests.get(url)
 
     for line in u.text.split("\n"):
         words = line.strip().split("\t")
         if len(words) > 1 and words[0] == msid.upper():
-            yellow_hi = float(words[3])
-            red_hi = float(words[5])
+            yellow_hi = float(words[cols[0]])
+            red_hi = float(words[cols[1]])
             break
 
     return yellow_hi, red_hi

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -249,7 +249,8 @@ def make_state_builder(name, args):
 def get_acis_limits(msid):
     """
     Get the current red and yellow hi limits for a given 
-    ACIS-related MSID. 
+    ACIS-related MSID, or the various limits for the 
+    focal plane temperature.
 
     Parameters
     ----------
@@ -257,6 +258,12 @@ def get_acis_limits(msid):
         The MSID to get the limits for, e.g. "1deamzt".
     """
     import requests
+
+    if msid == "fptemp":
+        fp_sens = -118.7
+        acis_i = -114.0
+        acis_s = -112.0
+        return fp_sens, acis_i, acis_s
 
     yellow_hi = None
     red_hi = None


### PR DESCRIPTION
We have code that parses the limits file for engineering telemetry, but not ACIS DEA HKP telemetry. This PR adds that functionality so the BEP and FEP models will get their yellow limits from the official file in the same manner. 