### PR TITLE
Make acis_thermal_check compatible with acisfp_check

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -606,7 +606,7 @@ class ACISThermalCheck(object):
             for rz in rzs:
                 ptimes = cxctime2plotdate(date2secs([rz.start, rz.stop]))
                 for ptime in ptimes:
-                    ax.axvline(ptime, ls='--', lw=2, color='g')
+                    ax.axvline(ptime, ls='--', color='g')
             filename = msid + '_valid.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -838,10 +838,11 @@ class ACISThermalCheck(object):
         """
         # Get temperature and other telemetry for 3 weeks prior to min(tstart, NOW)
         the_msid = self.msid
-        for key, value in self.other_map.items():
-            if value == self.msid:
-                the_msid = key
-                break
+        if self.other_map is not None:
+            for key, value in self.other_map.items():
+                if value == self.msid:
+                    the_msid = key
+                    break
         telem_msids = [the_msid, 'sim_z', 'dp_pitch', 'dp_dpa_power', 'roll']
 
         # If the calling program has other MSIDs it wishes us to check, add them

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -14,7 +14,7 @@ import pickle
 import numpy as np
 import Ska.DBI
 import Ska.Numpy
-from Chandra.Time import DateTime, date2secs
+from Chandra.Time import DateTime
 import matplotlib.pyplot as plt
 from Ska.Matplotlib import cxctime2plotdate, \
     pointpair, plot_cxctime
@@ -618,7 +618,7 @@ class ACISThermalCheck(object):
             ax.grid()
             # add lines for perigee passages
             for rz in rzs:
-                ptimes = cxctime2plotdate(date2secs([rz.start, rz.stop]))
+                ptimes = cxctime2plotdate([rz.tstart, rz.tstop])
                 for ptime in ptimes:
                     ax.axvline(ptime, ls='--', color='g')
             filename = msid + '_valid.png'

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -545,8 +545,9 @@ class ACISThermalCheck(object):
         # page to appear in this order
         pred = OrderedDict([(self.msid, model.comp[self.msid].mvals),
                             ('pitch', model.comp['pitch'].mvals),
-                            ('tscpos', model.comp['sim_z'].mvals),
-                            ('roll', model.comp['roll'].mvals)])
+                            ('tscpos', model.comp['sim_z'].mvals)])
+        if "roll" in model.comp:
+            pred["roll"] = model.comp['roll'].mvals
 
         # Interpolate the model and data to a consistent set of times
         idxs = Ska.Numpy.interpolate(np.arange(len(tlm)), tlm['date'], model.times,

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -157,10 +157,7 @@ class ACISThermalCheck(object):
         # Second, convert reST to HTML
         self.rst_to_html(args.outdir, proc)
 
-        return dict(args=args, states=pred['states'], times=pred['times'],
-                    temps=pred['temps'], plots=pred['plots'],
-                    viols=pred['viols'], proc=proc,
-                    plots_validation=plots_validation)
+        return
 
     def make_week_predict(self, tstart, tstop, tlm, T_init, model_spec,
                           outdir):

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -151,8 +151,15 @@ class ACISThermalCheck(object):
 
         # Write everything to the web page.
         # First, write the reStructuredText file.
-        self.write_index_rst(self.bsdir, args.outdir, proc, plots_validation, 
-                             pred, valid_viols=valid_viols)
+
+        # Set up the context for the reST file
+        context = {'bsdir': self.bsdir,
+                   'plots': pred["plots"],
+                   'viols': pred["viols"],
+                   'valid_viols': valid_viols,
+                   'proc': proc,
+                   'plots_validation': plots_validation}
+        self.write_index_rst(self.bsdir, args.outdir, context)
 
         # Second, convert reST to HTML
         self.rst_to_html(args.outdir, proc)
@@ -691,10 +698,9 @@ class ACISThermalCheck(object):
         outtext = del_colgroup.sub('', open(outfile).read())
         open(outfile, 'w').write(outtext)
 
-    def write_index_rst(self, bsdir, outdir, proc, plots_validation, 
-                        pred, valid_viols=None):
+    def write_index_rst(self, bsdir, outdir, context):
         """
-        Make output text (in reST format) in outdir, using jinja2
+        Make output text (in ReST format) in outdir, using jinja2
         to fill out the template. 
 
         Parameters
@@ -705,30 +711,13 @@ class ACISThermalCheck(object):
             the case.
         outdir : string
             Path to the location where the outputs will be written.
-        proc : dict
-            A dictionary of general information used in the output
-        plots_validation : dict
-            A dictionary of validation plots and their associated info
-        valid_viols : dict, optional
-            A dictionary of validation violations (if there were any)
-        plots : dict, optional
-            A dictionary of prediction plots and their associated info
-            (if there were any) 
-        viols : dict, optional
-            A dictionary of violations for the predicted temperatures
-            (if there were any)
+        context : dict
+            Dictionary of items which will be written to the ReST file.
         """
         import jinja2
 
         outfile = os.path.join(outdir, 'index.rst')
         mylog.info('Writing report file %s' % outfile)
-        # Set up the context for the reST file
-        context = {'bsdir': bsdir,
-                   'plots': pred["plots"],
-                   'viols': pred["viols"],
-                   'valid_viols': valid_viols,
-                   'proc': proc,
-                   'plots_validation': plots_validation}
         # Open up the reST template and send the context to it using jinja2
         index_template_file = ('index_template.rst'
                                if bsdir else

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -7,7 +7,7 @@ matplotlib.use('Agg')
 
 import os
 from pprint import pformat
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import re
 import time
 import pickle
@@ -197,8 +197,7 @@ class ACISThermalCheck(object):
             pred = self.make_week_predict(tstart, tstop, tlm, args.T_init,
                                           args.model_spec, args.outdir)
         else:
-            pred = dict(plots=None, viols=None, times=None, states=None,
-                        temps=None)
+            pred = defaultdict(lambda: None)
 
         # Validation
         # Make the validation plots

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -604,12 +604,9 @@ class ACISThermalCheck(object):
             ax.grid()
             # add lines for perigee passages
             for rz in rzs:
-                rz_start = cxctime2plotdate(date2secs(rz.start))
-                perigee = cxctime2plotdate(date2secs(rz.perigee))
-                rz_stop = cxctime2plotdate(date2secs(rz.stop))
-                ax.axvline(rz_start, ls='--', lw=2, color='g')
-                ax.axvline(perigee, ls='--', lw=2, color='g')
-                ax.axvline(rz_stop, ls='--', lw=2, color='g')
+                ptimes = cxctime2plotdate(date2secs([rz.start, rz.perigee, rz.stop]))
+                for ptime in ptimes:
+                    ax.axvline(ptime, ls='--', lw=2, color='g')
             filename = msid + '_valid.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -704,7 +704,7 @@ class ACISThermalCheck(object):
         outtext = del_colgroup.sub('', open(outfile).read())
         open(outfile, 'w').write(outtext)
 
-    def write_index_rst(self, bsdir, outdir, context):
+    def write_index_rst(self, bsdir, outdir, context, template_path=None):
         """
         Make output text (in ReST format) in outdir, using jinja2
         to fill out the template. 
@@ -719,17 +719,22 @@ class ACISThermalCheck(object):
             Path to the location where the outputs will be written.
         context : dict
             Dictionary of items which will be written to the ReST file.
+        template_path : string, optional
+            Optional path to look for the ReST template. Default is to
+            use the one internal to acis_thermal_check.
         """
         import jinja2
-
+        if template_path is None:
+            template_path = os.path.join(TASK_DATA, 'acis_thermal_check',
+                                         'templates')
         outfile = os.path.join(outdir, 'index.rst')
         mylog.info('Writing report file %s' % outfile)
         # Open up the reST template and send the context to it using jinja2
         index_template_file = ('index_template.rst'
                                if bsdir else
                                'index_template_val_only.rst')
-        index_template = open(os.path.join(TASK_DATA, 'acis_thermal_check', 
-                                           'templates', index_template_file)).read()
+        index_template = open(os.path.join(template_path, 
+                                           index_template_file)).read()
         index_template = re.sub(r' %}\n', ' %}', index_template)
         template = jinja2.Template(index_template)
         # Render the template and write it to a file

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -212,8 +212,7 @@ class ACISThermalCheck(object):
         # First, write the reStructuredText file.
 
         self.write_index_rst(self.bsdir, args.outdir, proc, plots_validation, 
-                             valid_viols=valid_viols, plots=pred['plots'], 
-                             viols=pred['viols'])
+                             pred, valid_viols=valid_viols)
         # Second, convert reST to HTML
         self.rst_to_html(args.outdir, proc)
 
@@ -738,7 +737,7 @@ class ACISThermalCheck(object):
         open(outfile, 'w').write(outtext)
 
     def write_index_rst(self, bsdir, outdir, proc, plots_validation, 
-                        valid_viols=None, plots=None, viols=None):
+                        pred, valid_viols=None):
         """
         Make output text (in reST format) in outdir, using jinja2
         to fill out the template. 
@@ -770,8 +769,8 @@ class ACISThermalCheck(object):
         mylog.info('Writing report file %s' % outfile)
         # Set up the context for the reST file
         context = {'bsdir': bsdir,
-                   'plots': plots,
-                   'viols': viols,
+                   'plots': pred["plots"],
+                   'viols': pred["viols"],
                    'valid_viols': valid_viols,
                    'proc': proc,
                    'plots_validation': plots_validation}

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -134,7 +134,7 @@ class ACISThermalCheck(object):
 
         # make predictions on a backstop file if defined
         if args.backstop_file is not None:
-            pred = self.make_week_predict(tstart, tstop, tlm, args.T_init,
+            pred = self.make_week_predict(tstart, tstop, tlm, args.T_init, 
                                           args.model_spec, args.outdir)
         else:
             pred = defaultdict(lambda: None)
@@ -822,7 +822,12 @@ class ACISThermalCheck(object):
             Length of telemetry request before ``tstart`` in days. Default: 14
         """
         # Get temperature and other telemetry for 3 weeks prior to min(tstart, NOW)
-        telem_msids = [self.msid, 'sim_z', 'dp_pitch', 'dp_dpa_power', 'roll']
+        the_msid = self.msid
+        for key, value in self.other_map.items():
+            if value == self.msid:
+                the_msid = key
+                break
+        telem_msids = [the_msid, 'sim_z', 'dp_pitch', 'dp_dpa_power', 'roll']
 
         # If the calling program has other MSIDs it wishes us to check, add them
         # to the list which is supposed to be grabbed from the engineering archive

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -604,7 +604,7 @@ class ACISThermalCheck(object):
             ax.grid()
             # add lines for perigee passages
             for rz in rzs:
-                ptimes = cxctime2plotdate(date2secs([rz.start, rz.perigee, rz.stop]))
+                ptimes = cxctime2plotdate(date2secs([rz.start, rz.stop]))
                 for ptime in ptimes:
                     ax.axvline(ptime, ls='--', lw=2, color='g')
             filename = msid + '_valid.png'

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -128,6 +128,10 @@ class ACISThermalCheck(object):
         is_weekly_load = args.backstop_file is not None
         tstart, tstop, tnow = self._determine_times(args.run_start,
                                                     is_weekly_load)
+        
+        proc["datestart"] = DateTime(tstart).date
+        if tstop is not None:
+            proc["datestop"] = DateTime(tstop).date
 
         # Get the telemetry values which will be used
         # for prediction and validation

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -124,8 +124,9 @@ class ACISThermalCheck(object):
 
         proc = self._setup_proc_and_logger(args)
 
-        tstart, tstop, tnow = self.determine_times(args.run_start, 
-                                                   args.backstop_file)
+        is_weekly_load = args.backstop_file is not None
+        tstart, tstop, tnow = self._determine_times(args.run_start,
+                                                    is_weekly_load)
 
         # Get the telemetry values which will be used
         # for prediction and validation
@@ -726,7 +727,16 @@ class ACISThermalCheck(object):
         open(outfile, 'w').write(template.render(**context))
 
     def _setup_proc_and_logger(self, args):
+        """
+        This method does some initial setup and logs important
+        information.
 
+        Parameters
+        ----------
+        args : ArgumentParser arguments
+            The command-line options object, which has the options
+            attached to it as attributes
+        """
         if not os.path.exists(args.outdir):
             os.mkdir(args.outdir)
 
@@ -763,11 +773,20 @@ class ACISThermalCheck(object):
                 self.bsdir = os.path.dirname(args.backstop_file)
         return proc
 
-    def determine_times(self, run_start, backstop_file):
+    def _determine_times(self, run_start, is_weekly_load):
+        """
+        Determine the start and stop times
+
+        Parameters
+        ----------
+        run_start : string
+            The starting date/time of the run.
+        is_weekly_load : boolean
+            Whether or not this is a weekly load.
+        """
         tnow = DateTime(run_start).secs
-        # Get tstart, tstop, commands from backstop file
-        # in args.backstop_file
-        if backstop_file is not None:
+        # Get tstart, tstop, commands from state builder
+        if is_weekly_load:
             # If we are running a model for a particular load,
             # get tstart, tstop, commands from backstop file
             # in args.backstop_file

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -151,9 +151,9 @@ class ACISThermalCheck(object):
 
         # Write everything to the web page.
         # First, write the reStructuredText file.
-
         self.write_index_rst(self.bsdir, args.outdir, proc, plots_validation, 
                              pred, valid_viols=valid_viols)
+
         # Second, convert reST to HTML
         self.rst_to_html(args.outdir, proc)
 


### PR DESCRIPTION
In order to integrate the focal plane temperature model with `acis_thermal_check`, some changes needed to be made, given how different `acisfp_check` is. 

A PR for `acisfp_check` which goes with this PR can be found at acisops/acisfp_check#8.

This PR also adds green dashed lines to validation plots marking perigee passages. 

This PR should not be merged until approval but also after the following tests have been performed:

- [x] Tests of the new `acisfp_check` against old loads
- [x] Testing the other model tools against old loads to make sure there are no changes
- [x] Test all model tools, including `acisfp_check`, against a few weekly loads