### PR TITLE
Improvements to thermal model plots and fixing run.dat

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -24,7 +24,7 @@ import acis_thermal_check
 version = acis_thermal_check.__version__
 from acis_thermal_check.utils import \
     config_logging, TASK_DATA, plot_two, \
-    mylog
+    mylog, plot_one, calc_off_nom_rolls
 from kadi import events
 
 class ACISThermalCheck(object):
@@ -508,6 +508,34 @@ class ACISThermalCheck(object):
         mylog.info('Writing plot file %s' % outfile)
         plots['pow_sim']['fig'].savefig(outfile)
         plots['pow_sim']['filename'] = filename
+
+        # Make a plot of off-nominal roll
+        plots['roll'] = plot_one(
+            fig_id=4,
+            title='Off-Nominal Roll (deg)',
+            xlabel='Date',
+            x=pointpair(states['tstart'], states['tstop']),
+            y=pointpair(calc_off_nom_rolls(states)),
+            ylabel='Roll Angle (deg)',
+            ylim=(-20.0, 20.0),
+            figsize=(7.5, 3.5))
+        # Add a vertical line to mark the start time of the load
+        plots['roll']['ax'].axvline(load_start, linestyle='-', color='g',
+                                    linewidth=2.0)
+        # Set the left limit of the plot to be -2 days before the load start
+        plots['roll']['ax'].set_xlim(plot_start, None)
+        # The next several lines ensure that the width of the axes
+        # of all the weekly prediction plots are the same.
+        w1, h1 = plots[self.name]['fig'].get_size_inches()
+        w2, h2 = plots['roll']['fig'].get_size_inches()
+        lm = plots[self.name]['fig'].subplotpars.left*w1/w2
+        rm = plots[self.name]['fig'].subplotpars.right*w1/w2
+        plots['roll']['fig'].subplots_adjust(left=lm, right=rm)
+        filename = 'roll.png'
+        outfile = os.path.join(outdir, filename)
+        mylog.info('Writing plot file %s' % outfile)
+        plots['roll']['fig'].savefig(outfile)
+        plots['roll']['filename'] = filename
 
         plots['default'] = plots[self.name]
 

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -514,7 +514,7 @@ class ACISThermalCheck(object):
 
         # Make a plot of off-nominal roll
         plots['roll'] = plot_one(
-            fig_id=4,
+            fig_id=fig_id,
             title='Off-Nominal Roll',
             xlabel='Date',
             x=pointpair(states['tstart'], states['tstop']),

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -457,10 +457,12 @@ class ACISThermalCheck(object):
                                    x2=pointpair(states['tstart'], states['tstop']),
                                    y2=pointpair(states['pitch']),
                                    title=self.MSIDs[msid],
+                                   xmin=plot_start,
                                    xlabel='Date',
                                    ylabel='Temperature (C)',
                                    ylabel2='Pitch (deg)',
-                                   ylim2=(40, 180))
+                                   ylim2=(40, 180),
+                                   figsize=(8.0, 4.0))
             # Add horizontal lines for the planning and caution limits
             plots[msid]['ax'].axhline(self.yellow[msid], linestyle='-', color='y',
                                       linewidth=2.0)
@@ -469,8 +471,6 @@ class ACISThermalCheck(object):
             # Add a vertical line to mark the start of the load
             plots[msid]['ax'].axvline(load_start, linestyle='-', color='g',
                                       linewidth=2.0)
-            # Set the left limit of the plot to be -2 days before the load start
-            plots[msid]['ax'].set_xlim(plot_start, None)
             filename = self.MSIDs[self.name].lower() + '.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)
@@ -488,16 +488,15 @@ class ACISThermalCheck(object):
             y=pointpair(states['ccd_count']),
             ylabel='CCD_COUNT',
             ylim=(-0.1, 6.1),
+            xmin=plot_start,
             x2=pointpair(states['tstart'], states['tstop']),
             y2=pointpair(states['simpos']),
             ylabel2='SIM-Z (steps)',
             ylim2=(-105000, 105000),
-            figsize=(7.5, 3.6))
+            figsize=(8.5, 4.0))
         # Add a vertical line to mark the start time of the load
         plots['pow_sim']['ax'].axvline(load_start, linestyle='-', color='g',
                                        linewidth=2.0)
-        # Set the left limit of the plot to be -2 days before the load start
-        plots['pow_sim']['ax'].set_xlim(plot_start, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
         w1, h1 = plots[self.name]['fig'].get_size_inches()
@@ -520,14 +519,13 @@ class ACISThermalCheck(object):
             xlabel='Date',
             x=pointpair(states['tstart'], states['tstop']),
             y=pointpair(calc_off_nom_rolls(states)),
+            xmin=plot_start,
             ylabel='Roll Angle (deg)',
             ylim=(-20.0, 20.0),
-            figsize=(7.5, 3.6))
+            figsize=(8.5, 4.0))
         # Add a vertical line to mark the start time of the load
         plots['roll']['ax'].axvline(load_start, linestyle='-', color='g',
                                     linewidth=2.0)
-        # Set the left limit of the plot to be -2 days before the load start
-        plots['roll']['ax'].set_xlim(plot_start, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
         w2, h2 = plots['roll']['fig'].get_size_inches()

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -468,6 +468,8 @@ class ACISThermalCheck(object):
             # Add a vertical line to mark the start of the load
             plots[msid]['ax'].axvline(load_start, linestyle='-', color='g',
                                       linewidth=2.0)
+            # Set the left limit of the plot to be -2 days before the load start
+            plots[msid]['ax'].set_xlim(load_start-2.0*86400.0, None)
             filename = self.MSIDs[self.name].lower() + '.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)
@@ -491,6 +493,8 @@ class ACISThermalCheck(object):
         # Add a vertical line to mark the start time of the load
         plots['pow_sim']['ax'].axvline(load_start, linestyle='-', color='g',
                                        linewidth=2.0)
+        # Set the left limit of the plot to be -2 days before the load start
+        plots['pow_sim']['ax'].set_xlim(load_start-2.0*86400.0, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
         w1, h1 = plots[self.name]['fig'].get_size_inches()

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -477,9 +477,11 @@ class ACISThermalCheck(object):
             plots[msid]['fig'].savefig(outfile)
             plots[msid]['filename'] = filename
 
+        fig_id += 1
+
         # Make a plot of ACIS CCDs and SIM-Z position
         plots['pow_sim'] = plot_two(
-            fig_id=3,
+            fig_id=fig_id,
             title='ACIS CCDs and SIM-Z position',
             xlabel='Date',
             x=pointpair(states['tstart'], states['tstop']),
@@ -498,6 +500,7 @@ class ACISThermalCheck(object):
         plots['pow_sim']['ax'].set_xlim(plot_start, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
+        w1, h1 = plots[self.name]['fig'].get_size_inches()
         w2, h2 = plots['pow_sim']['fig'].get_size_inches()
         lm = plots[self.name]['fig'].subplotpars.left*w1/w2
         rm = plots[self.name]['fig'].subplotpars.right*w1/w2
@@ -507,6 +510,8 @@ class ACISThermalCheck(object):
         mylog.info('Writing plot file %s' % outfile)
         plots['pow_sim']['fig'].savefig(outfile)
         plots['pow_sim']['filename'] = filename
+
+        fig_id += 1
 
         # Make a plot of off-nominal roll
         plots['roll'] = plot_one(
@@ -525,7 +530,6 @@ class ACISThermalCheck(object):
         plots['roll']['ax'].set_xlim(plot_start, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
-        w1, h1 = plots[self.name]['fig'].get_size_inches()
         w2, h2 = plots['roll']['fig'].get_size_inches()
         lm = plots[self.name]['fig'].subplotpars.left*w1/w2
         rm = plots[self.name]['fig'].subplotpars.right*w1/w2

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -498,7 +498,6 @@ class ACISThermalCheck(object):
         plots['pow_sim']['ax'].set_xlim(plot_start, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
-        w1, h1 = plots[self.name]['fig'].get_size_inches()
         w2, h2 = plots['pow_sim']['fig'].get_size_inches()
         lm = plots[self.name]['fig'].subplotpars.left*w1/w2
         rm = plots[self.name]['fig'].subplotpars.right*w1/w2

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -444,7 +444,7 @@ class ACISThermalCheck(object):
         # Start time of loads being reviewed expressed in units for plotdate()
         load_start = cxctime2plotdate([load_start])[0]
         # Value for left side of plots
-        plot_start = max(load_start-2.0*86400.0, cxctime2plotdate([times[0]])[0])
+        plot_start = max(load_start-2.0, cxctime2plotdate([times[0]])[0])
         # Make the plots for the temperature prediction. This loop allows us
         # to make a plot for more than one temperature, but we currently only 
         # do one. Plots are of temperature on the left axis and pitch on the

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -492,7 +492,7 @@ class ACISThermalCheck(object):
             y2=pointpair(states['simpos']),
             ylabel2='SIM-Z (steps)',
             ylim2=(-105000, 105000),
-            figsize=(7.5, 3.5))
+            figsize=(7.5, 3.6))
         # Add a vertical line to mark the start time of the load
         plots['pow_sim']['ax'].axvline(load_start, linestyle='-', color='g',
                                        linewidth=2.0)
@@ -522,7 +522,7 @@ class ACISThermalCheck(object):
             y=pointpair(calc_off_nom_rolls(states)),
             ylabel='Roll Angle (deg)',
             ylim=(-20.0, 20.0),
-            figsize=(7.5, 3.5))
+            figsize=(7.5, 3.6))
         # Add a vertical line to mark the start time of the load
         plots['roll']['ax'].axvline(load_start, linestyle='-', color='g',
                                     linewidth=2.0)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -443,7 +443,8 @@ class ACISThermalCheck(object):
 
         # Start time of loads being reviewed expressed in units for plotdate()
         load_start = cxctime2plotdate([load_start])[0]
-
+        # Value for left side of plots
+        plot_start = max(load_start-2.0*86400.0, cxctime2plotdate([times[0]])[0])
         # Make the plots for the temperature prediction. This loop allows us
         # to make a plot for more than one temperature, but we currently only 
         # do one. Plots are of temperature on the left axis and pitch on the
@@ -469,7 +470,7 @@ class ACISThermalCheck(object):
             plots[msid]['ax'].axvline(load_start, linestyle='-', color='g',
                                       linewidth=2.0)
             # Set the left limit of the plot to be -2 days before the load start
-            plots[msid]['ax'].set_xlim(load_start-2.0*86400.0, None)
+            plots[msid]['ax'].set_xlim(plot_start, None)
             filename = self.MSIDs[self.name].lower() + '.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)
@@ -494,7 +495,7 @@ class ACISThermalCheck(object):
         plots['pow_sim']['ax'].axvline(load_start, linestyle='-', color='g',
                                        linewidth=2.0)
         # Set the left limit of the plot to be -2 days before the load start
-        plots['pow_sim']['ax'].set_xlim(load_start-2.0*86400.0, None)
+        plots['pow_sim']['ax'].set_xlim(plot_start, None)
         # The next several lines ensure that the width of the axes
         # of all the weekly prediction plots are the same.
         w1, h1 = plots[self.name]['fig'].get_size_inches()

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -516,7 +516,7 @@ class ACISThermalCheck(object):
         # Make a plot of off-nominal roll
         plots['roll'] = plot_one(
             fig_id=4,
-            title='Off-Nominal Roll (deg)',
+            title='Off-Nominal Roll',
             xlabel='Date',
             x=pointpair(states['tstart'], states['tstop']),
             y=pointpair(calc_off_nom_rolls(states)),

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -42,6 +42,7 @@ No {{proc.msid}} Violations
 
 .. image:: {{plots.default.filename}}
 .. image:: {{plots.pow_sim.filename}}
+.. image:: {{plots.roll.filename}}
 
 ==============================
 {{proc.name}} Model Validation

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -78,6 +78,53 @@ def config_logging(outdir, verbose):
         filehandler.setLevel(logging.DEBUG)
     logger.addHandler(filehandler)
 
+def plot_one(fig_id, x, y, linestyle='-', 
+             color='blue', ylim=None, 
+             xlabel='', ylabel='', title='',
+             figsize=(7, 3.5)):
+    """
+    Plot one quantities with a date x-axis and a left
+    y-axis.
+
+    Parameters
+    ----------
+    fig_id : integer
+        The ID for this particular figure.
+    x : NumPy array
+        Times in seconds since the beginning of the mission for
+        the left y-axis quantity.
+    y : NumPy array
+        Quantity to plot against the times on the left x-axis.
+    linestyle : string, optional
+        The style of the line for the left y-axis.
+    color : string, optional
+        The color of the line for the left y-axis.
+    xlabel : string, optional
+        The label of the x-axis.
+    ylabel : string, optional
+        The label for the left y-axis.
+    title : string, optional
+        The title for the plot.
+    figsize : 2-tuple of floats
+        Size of plot in width and height in inches.
+    """
+    # Convert times to dates
+    xt = cxctime2plotdate(x)
+    fig = plt.figure(fig_id, figsize=figsize)
+    fig.clf()
+    ax = fig.add_subplot(1, 1, 1)
+    # Plot left y-axis
+    ax.plot_date(xt, y, fmt='-', linestyle=linestyle, color=color)
+    ax.set_xlim(min(xt), max(xt))
+    if ylim:
+        ax.set_ylim(*ylim)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid()
+
+    return {'fig': fig, 'ax': ax}
+
 def plot_two(fig_id, x, y, x2, y2,
              linestyle='-', linestyle2='-',
              color='blue', color2='magenta',

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -79,7 +79,8 @@ def config_logging(outdir, verbose):
     logger.addHandler(filehandler)
 
 def plot_one(fig_id, x, y, linestyle='-', 
-             color='blue', ylim=None, 
+             color='blue', xmin=None,
+             xmax=None, ylim=None, 
              xlabel='', ylabel='', title='',
              figsize=(7, 3.5)):
     """
@@ -115,7 +116,11 @@ def plot_one(fig_id, x, y, linestyle='-',
     ax = fig.add_subplot(1, 1, 1)
     # Plot left y-axis
     ax.plot_date(xt, y, fmt='-', linestyle=linestyle, color=color)
-    ax.set_xlim(min(xt), max(xt))
+    if xmin is None:
+        xmin = min(xt)
+    if xmax is None:
+        xmax = max(xt)
+    ax.set_xlim(xmin, xmax)
     if ylim:
         ax.set_ylim(*ylim)
     ax.set_xlabel(xlabel)
@@ -126,14 +131,14 @@ def plot_one(fig_id, x, y, linestyle='-',
     Ska.Matplotlib.set_time_ticks(ax)
     [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
 
-    fig.subplots_adjust(bottom=0.22)
+    fig.subplots_adjust(bottom=0.22, right=0.87)
 
     return {'fig': fig, 'ax': ax}
 
 def plot_two(fig_id, x, y, x2, y2,
              linestyle='-', linestyle2='-',
              color='blue', color2='magenta',
-             ylim=None, ylim2=None,
+             xmin=None, xmax=None, ylim=None, ylim2=None,
              xlabel='', ylabel='', ylabel2='', title='',
              figsize=(7, 3.5)):
     """
@@ -180,7 +185,11 @@ def plot_two(fig_id, x, y, x2, y2,
     ax = fig.add_subplot(1, 1, 1)
     # Plot left y-axis
     ax.plot_date(xt, y, fmt='-', linestyle=linestyle, color=color)
-    ax.set_xlim(min(xt), max(xt))
+    if xmin is None:
+        xmin = min(xt)
+    if xmax is None:
+        xmax = max(xt)
+    ax.set_xlim(xmin, xmax)
     if ylim:
         ax.set_ylim(*ylim)
     ax.set_xlabel(xlabel)
@@ -193,7 +202,7 @@ def plot_two(fig_id, x, y, x2, y2,
     ax2 = ax.twinx()
     xt2 = cxctime2plotdate(x2)
     ax2.plot_date(xt2, y2, fmt='-', linestyle=linestyle2, color=color2)
-    ax2.set_xlim(min(xt), max(xt))
+    ax2.set_xlim(xmin, xmax)
     if ylim2:
         ax2.set_ylim(*ylim2)
     ax2.set_ylabel(ylabel2, color=color2)
@@ -203,7 +212,7 @@ def plot_two(fig_id, x, y, x2, y2,
     [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
     [label.set_color(color2) for label in ax2.yaxis.get_ticklabels()]
 
-    fig.subplots_adjust(bottom=0.22)
+    fig.subplots_adjust(bottom=0.22, right=0.87)
 
     return {'fig': fig, 'ax': ax, 'ax2': ax2}
 

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -100,6 +100,12 @@ def plot_one(fig_id, x, y, linestyle='-',
         The style of the line for the left y-axis.
     color : string, optional
         The color of the line for the left y-axis.
+    xmin : float, optional
+        The left-most value of the x-axis.
+    xmax : float, optional
+        The right-most value of the x-axis.
+    ylim : 2-tuple, optional
+        The limits for the left y-axis.
     xlabel : string, optional
         The label of the x-axis.
     ylabel : string, optional
@@ -167,6 +173,14 @@ def plot_two(fig_id, x, y, x2, y2,
         The color of the line for the left y-axis.
     color2 : string, optional
         The color of the line for the right y-axis.
+    xmin : float, optional
+        The left-most value of the x-axis.
+    xmax : float, optional
+        The right-most value of the x-axis.
+    ylim : 2-tuple, optional
+        The limits for the left y-axis.
+    ylim2 : 2-tuple, optional
+        The limits for the right y-axis.
     xlabel : string, optional
         The label of the x-axis.
     ylabel : string, optional

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -123,6 +123,11 @@ def plot_one(fig_id, x, y, linestyle='-',
     ax.set_title(title)
     ax.grid()
 
+    Ska.Matplotlib.set_time_ticks(ax)
+    [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
+
+    fig.subplots_adjust(bottom=0.22)
+
     return {'fig': fig, 'ax': ax}
 
 def plot_two(fig_id, x, y, x2, y2,

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -51,24 +51,31 @@ def config_logging(outdir, verbose):
     rootlogger = logging.getLogger()
     rootlogger.addHandler(NullHandler())
 
+    logger = logging.getLogger('acis_thermal_check')
+    logger.setLevel(logging.DEBUG)
+
     # Set numerical values for the different log levels
     loglevel = {0: logging.CRITICAL,
                 1: logging.INFO,
                 2: logging.DEBUG}.get(verbose, logging.INFO)
 
-    logger = logging.getLogger('acis_thermal_check')
-    logger.setLevel(loglevel)
-
     formatter = logging.Formatter('%(message)s')
 
     console = logging.StreamHandler()
     console.setFormatter(formatter)
+    console.setLevel(loglevel)
     logger.addHandler(console)
 
     logfile = os.path.join(outdir, 'run.dat')
 
     filehandler = logging.FileHandler(filename=logfile, mode='w')
     filehandler.setFormatter(formatter)
+    # Set the file loglevel to be at least INFO,
+    # but override to DEBUG if that is requested at the
+    # command line
+    filehandler.setLevel(logging.INFO)
+    if loglevel == logging.DEBUG:
+        filehandler.setLevel(logging.DEBUG)
     logger.addHandler(filehandler)
 
 def plot_two(fig_id, x, y, x2, y2,


### PR DESCRIPTION
This PR makes some adjustments to the plots on the ACIS thermal model pages and fixes a bug. 

1. Adjust the left edge of the plot so that we show a maximum of two days before the load starts regardless of when the thermal model is run.
2. Add a prediction plot for off-nominal roll. 
3. Apply the fix from acisops/psmc_check#3 in order to make sure we log to run.dat even if `verbose=0`.