### PR TITLE
Streamline and simplify acis_thermal_check, finish regression testing setup

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2-dev0"
+__version__ = "2.3.0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -2,13 +2,9 @@ __version__ = "2.2-dev0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck
-from acis_thermal_check.state_builder import \
-    SQLStateBuilder, ACISStateBuilder, \
-    HDF5StateBuilder, state_builders
 from acis_thermal_check.utils import \
     calc_off_nom_rolls, get_options, \
-    get_acis_limits, make_state_builder, \
-    mylog
+    get_acis_limits, mylog
 
 def test(*args, **kwargs):
     '''

--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.0"
+__version__ = "2.2-dev0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -654,7 +654,9 @@ class ACISThermalCheck(object):
             # or the limits for the focal plane model
             if self.msid == msid:
                 if msid == "fptemp":
-                    pass
+                    fp_sens, acis_s, acis_i = get_acis_limits("fptemp")
+                    ax.axhline(acis_i, linestyle='-.', color='purple')
+                    ax.axhline(acis_s, linestyle='-.', color='blue')
                 else:
                     ax.axhline(self.yellow[self.name], linestyle='-', color='y')
                     ax.axhline(self.yellow[self.name] - self.margin[self.name],

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -447,43 +447,34 @@ class ACISThermalCheck(object):
         load_start = cxctime2plotdate([load_start])[0]
         # Value for left side of plots
         plot_start = max(load_start-2.0, cxctime2plotdate([times[0]])[0])
-        # Make the plots for the temperature prediction. This loop allows us
-        # to make a plot for more than one temperature, but we currently only 
-        # do one. Plots are of temperature on the left axis and pitch on the
-        # right axis. 
-        mylog.info('Making temperature prediction plots')
-        for fig_id, msid in enumerate((self.name,)):
-            plots[msid] = plot_two(fig_id=fig_id + 1,
-                                   x=times,
-                                   y=temps[msid],
-                                   x2=pointpair(states['tstart'], states['tstop']),
-                                   y2=pointpair(states['pitch']),
-                                   title=self.MSIDs[msid],
-                                   xmin=plot_start,
-                                   xlabel='Date',
-                                   ylabel='Temperature (C)',
-                                   ylabel2='Pitch (deg)',
-                                   ylim2=(40, 180),
-                                   figsize=(8.0, 4.0))
-            # Add horizontal lines for the planning and caution limits
-            plots[msid]['ax'].axhline(self.yellow[msid], linestyle='-', color='y',
-                                      linewidth=2.0)
-            plots[msid]['ax'].axhline(self.yellow[msid] - self.margin[msid], linestyle='--',
-                                      color='y', linewidth=2.0)
-            # Add a vertical line to mark the start of the load
-            plots[msid]['ax'].axvline(load_start, linestyle='-', color='g',
-                                      linewidth=2.0)
-            filename = self.MSIDs[self.name].lower() + '.png'
-            outfile = os.path.join(outdir, filename)
-            mylog.info('Writing plot file %s' % outfile)
-            plots[msid]['fig'].savefig(outfile)
-            plots[msid]['filename'] = filename
 
-        fig_id += 1
+        w1 = None
+        mylog.info('Making temperature prediction plots')
+        plots[self.name] = plot_two(fig_id=1, x=times, y=temps[self.name],
+                                    x2=pointpair(states['tstart'], states['tstop']),
+                                    y2=pointpair(states['pitch']),
+                                    title=self.MSIDs[self.name], xmin=plot_start,
+                                    xlabel='Date', ylabel='Temperature (C)',
+                                    ylabel2='Pitch (deg)', ylim2=(40, 180),
+                                    figsize=(8.0, 4.0), width=w1, load_start=load_start)
+        # Add horizontal lines for the planning and caution limits
+        plots[self.name]['ax'].axhline(self.yellow[self.name], linestyle='-', color='y',
+                                       linewidth=2.0)
+        plots[self.name]['ax'].axhline(self.yellow[self.name]-self.margin[self.name], 
+                                       linestyle='--', color='y', linewidth=2.0)
+        filename = self.MSIDs[self.name].lower() + '.png'
+        outfile = os.path.join(outdir, filename)
+        mylog.info('Writing plot file %s' % outfile)
+        plots[self.name]['fig'].savefig(outfile)
+        plots[self.name]['filename'] = filename
+
+        # The next line is to ensure that the width of the axes
+        # of all the weekly prediction plots are the same.
+        w1, _ = plots[self.name]['fig'].get_size_inches()
 
         # Make a plot of ACIS CCDs and SIM-Z position
         plots['pow_sim'] = plot_two(
-            fig_id=fig_id,
+            fig_id=2,
             title='ACIS CCDs and SIM-Z position',
             xlabel='Date',
             x=pointpair(states['tstart'], states['tstop']),
@@ -495,28 +486,16 @@ class ACISThermalCheck(object):
             y2=pointpair(states['simpos']),
             ylabel2='SIM-Z (steps)',
             ylim2=(-105000, 105000),
-            figsize=(8.5, 4.0))
-        # Add a vertical line to mark the start time of the load
-        plots['pow_sim']['ax'].axvline(load_start, linestyle='-', color='g',
-                                       linewidth=2.0)
-        # The next several lines ensure that the width of the axes
-        # of all the weekly prediction plots are the same.
-        w1, h1 = plots[self.name]['fig'].get_size_inches()
-        w2, h2 = plots['pow_sim']['fig'].get_size_inches()
-        lm = plots[self.name]['fig'].subplotpars.left*w1/w2
-        rm = plots[self.name]['fig'].subplotpars.right*w1/w2
-        plots['pow_sim']['fig'].subplots_adjust(left=lm, right=rm)
+            figsize=(8.5, 4.0), width=w1, load_start=load_start)
         filename = 'pow_sim.png'
         outfile = os.path.join(outdir, filename)
         mylog.info('Writing plot file %s' % outfile)
         plots['pow_sim']['fig'].savefig(outfile)
         plots['pow_sim']['filename'] = filename
 
-        fig_id += 1
-
         # Make a plot of off-nominal roll
         plots['roll'] = plot_one(
-            fig_id=fig_id,
+            fig_id=3,
             title='Off-Nominal Roll',
             xlabel='Date',
             x=pointpair(states['tstart'], states['tstop']),
@@ -524,16 +503,7 @@ class ACISThermalCheck(object):
             xmin=plot_start,
             ylabel='Roll Angle (deg)',
             ylim=(-20.0, 20.0),
-            figsize=(8.5, 4.0))
-        # Add a vertical line to mark the start time of the load
-        plots['roll']['ax'].axvline(load_start, linestyle='-', color='g',
-                                    linewidth=2.0)
-        # The next several lines ensure that the width of the axes
-        # of all the weekly prediction plots are the same.
-        w2, h2 = plots['roll']['fig'].get_size_inches()
-        lm = plots[self.name]['fig'].subplotpars.left*w1/w2
-        rm = plots[self.name]['fig'].subplotpars.right*w1/w2
-        plots['roll']['fig'].subplots_adjust(left=lm, right=rm)
+            figsize=(8.5, 4.0), width=w1, load_start=load_start)
         filename = 'roll.png'
         outfile = os.path.join(outdir, filename)
         mylog.info('Writing plot file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -152,16 +152,11 @@ class ACISThermalCheck(object):
 
         # Set up the context for the reST file
         context = {'bsdir': self.bsdir,
+                   'viols': pred["viols"],
                    'plots': pred["plots"],
                    'valid_viols': valid_viols,
                    'proc': proc,
                    'plots_validation': plots_validation}
-        if self.msid == "fptemp":
-            for viol in ["ACIS_I", "ACIS_S", "fp_sens", "cti"]:
-                key = "%s_viols" % viol
-                context[key] = pred[key]
-        else:
-            context["viols"] = pred["viols"]
         self.write_index_rst(self.bsdir, self.args.outdir, context)
 
         # Second, convert reST to HTML

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -826,7 +826,8 @@ class ACISThermalCheck(object):
                     msid=self.msid.upper(),
                     name=self.name.upper(),
                     hist_limit=self.hist_limit)
-        proc["msid_limit"] = self.yellow[self.name] - self.margin[self.name]
+        if self.msid != "fptemp":
+            proc["msid_limit"] = self.yellow[self.name] - self.margin[self.name]
         mylog.info('##############################'
                    '#######################################')
         mylog.info('# %s_check run at %s by %s'

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -416,7 +416,7 @@ class ACISThermalCheck(object):
         out.close()
 
     def _make_state_plots(self, plots, num_figs, w1, plot_start,
-                          outdir, states, load_start):
+                          outdir, states, load_start, figsize=(8.5, 4.0)):
         # Make a plot of ACIS CCDs and SIM-Z position
         plots['pow_sim'] = plot_two(
             fig_id=num_figs+1,
@@ -431,7 +431,7 @@ class ACISThermalCheck(object):
             y2=pointpair(states['simpos']),
             ylabel2='SIM-Z (steps)',
             ylim2=(-105000, 105000),
-            figsize=(8.5, 4.0), width=w1, load_start=load_start)
+            figsize=figsize, width=w1, load_start=load_start)
         filename = 'pow_sim.png'
         outfile = os.path.join(outdir, filename)
         mylog.info('Writing plot file %s' % outfile)
@@ -448,7 +448,7 @@ class ACISThermalCheck(object):
             xmin=plot_start,
             ylabel='Roll Angle (deg)',
             ylim=(-20.0, 20.0),
-            figsize=(8.5, 4.0), width=w1, load_start=load_start)
+            figsize=figsize, width=w1, load_start=load_start)
         filename = 'roll.png'
         outfile = os.path.join(outdir, filename)
         mylog.info('Writing plot file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -421,6 +421,46 @@ class ACISThermalCheck(object):
         Ska.Numpy.pprint(temp_array, fmt, out)
         out.close()
 
+    def _make_state_plots(self, plots, num_figs, w1, plot_start,
+                          outdir, states, load_start):
+        # Make a plot of ACIS CCDs and SIM-Z position
+        plots['pow_sim'] = plot_two(
+            fig_id=num_figs+1,
+            title='ACIS CCDs and SIM-Z position',
+            xlabel='Date',
+            x=pointpair(states['tstart'], states['tstop']),
+            y=pointpair(states['ccd_count']),
+            ylabel='CCD_COUNT',
+            ylim=(-0.1, 6.1),
+            xmin=plot_start,
+            x2=pointpair(states['tstart'], states['tstop']),
+            y2=pointpair(states['simpos']),
+            ylabel2='SIM-Z (steps)',
+            ylim2=(-105000, 105000),
+            figsize=(8.5, 4.0), width=w1, load_start=load_start)
+        filename = 'pow_sim.png'
+        outfile = os.path.join(outdir, filename)
+        mylog.info('Writing plot file %s' % outfile)
+        plots['pow_sim']['fig'].savefig(outfile)
+        plots['pow_sim']['filename'] = filename
+
+        # Make a plot of off-nominal roll
+        plots['roll'] = plot_one(
+            fig_id=num_figs+2,
+            title='Off-Nominal Roll',
+            xlabel='Date',
+            x=pointpair(states['tstart'], states['tstop']),
+            y=pointpair(calc_off_nom_rolls(states)),
+            xmin=plot_start,
+            ylabel='Roll Angle (deg)',
+            ylim=(-20.0, 20.0),
+            figsize=(8.5, 4.0), width=w1, load_start=load_start)
+        filename = 'roll.png'
+        outfile = os.path.join(outdir, filename)
+        mylog.info('Writing plot file %s' % outfile)
+        plots['roll']['fig'].savefig(outfile)
+        plots['roll']['filename'] = filename
+
     def make_prediction_plots(self, outdir, states, times, temps, load_start):
         """
         Make plots of the thermal prediction as well as associated 
@@ -472,43 +512,8 @@ class ACISThermalCheck(object):
         # of all the weekly prediction plots are the same.
         w1, _ = plots[self.name]['fig'].get_size_inches()
 
-        # Make a plot of ACIS CCDs and SIM-Z position
-        plots['pow_sim'] = plot_two(
-            fig_id=2,
-            title='ACIS CCDs and SIM-Z position',
-            xlabel='Date',
-            x=pointpair(states['tstart'], states['tstop']),
-            y=pointpair(states['ccd_count']),
-            ylabel='CCD_COUNT',
-            ylim=(-0.1, 6.1),
-            xmin=plot_start,
-            x2=pointpair(states['tstart'], states['tstop']),
-            y2=pointpair(states['simpos']),
-            ylabel2='SIM-Z (steps)',
-            ylim2=(-105000, 105000),
-            figsize=(8.5, 4.0), width=w1, load_start=load_start)
-        filename = 'pow_sim.png'
-        outfile = os.path.join(outdir, filename)
-        mylog.info('Writing plot file %s' % outfile)
-        plots['pow_sim']['fig'].savefig(outfile)
-        plots['pow_sim']['filename'] = filename
-
-        # Make a plot of off-nominal roll
-        plots['roll'] = plot_one(
-            fig_id=3,
-            title='Off-Nominal Roll',
-            xlabel='Date',
-            x=pointpair(states['tstart'], states['tstop']),
-            y=pointpair(calc_off_nom_rolls(states)),
-            xmin=plot_start,
-            ylabel='Roll Angle (deg)',
-            ylim=(-20.0, 20.0),
-            figsize=(8.5, 4.0), width=w1, load_start=load_start)
-        filename = 'roll.png'
-        outfile = os.path.join(outdir, filename)
-        mylog.info('Writing plot file %s' % outfile)
-        plots['roll']['fig'].savefig(outfile)
-        plots['roll']['filename'] = filename
+        self._make_state_plots(plots, 1, w1, plot_start,
+                               outdir, states, load_start)
 
         plots['default'] = plots[self.name]
 

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -487,7 +487,7 @@ class ACISThermalCheck(object):
         plots[self.name] = plot_two(fig_id=1, x=times, y=temps[self.name],
                                     x2=pointpair(states['tstart'], states['tstop']),
                                     y2=pointpair(states['pitch']),
-                                    title=self.msid, xmin=plot_start,
+                                    title=self.msid.upper(), xmin=plot_start,
                                     xlabel='Date', ylabel='Temperature (C)',
                                     ylabel2='Pitch (deg)', ylim2=(40, 180),
                                     figsize=(8.0, 4.0), width=w1, load_start=load_start)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -656,10 +656,9 @@ class ACISThermalCheck(object):
                 if msid == "fptemp":
                     pass
                 else:
-                    ax.axhline(self.yellow[self.name], linestyle='-', color='y',
-                               linewidth=2.0)
-                    ax.axhline(self.yellow[self.name] - self.margin[self.name], 
-                               linestyle='--', color='y', linewidth=2.0)
+                    ax.axhline(self.yellow[self.name], linestyle='-', color='y')
+                    ax.axhline(self.yellow[self.name] - self.margin[self.name],
+                               linestyle='--', color='y')
             filename = msid + '_valid.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -110,7 +110,7 @@ class ACISThermalCheck(object):
         self.args = args
         self.state_builder = make_state_builder(args.state_builder, args)
 
-    def driver(self):
+    def run(self):
         """
         The main interface to all of ACISThermalCheck's functions.
         This method must be called by the particular thermal model

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -639,7 +639,8 @@ class ACISThermalCheck(object):
             ticklocs, fig, ax = plot_cxctime(model.times, pred[msid] / scale,
                                              fig=fig, fmt='-b')
             if np.any(~good_mask):
-                ticklocs, fig, ax = plot_cxctime(model.times[~good_mask], tlm[msid][~good_mask] / scale,
+                ticklocs, fig, ax = plot_cxctime(model.times[~good_mask], 
+                                                 tlm[msid][~good_mask] / scale,
                                                  fig=fig, fmt='.c')
             ax.set_title(msid.upper() + ' validation')
             ax.set_ylabel(labels[msid])
@@ -649,6 +650,16 @@ class ACISThermalCheck(object):
                 ptimes = cxctime2plotdate([rz.tstart, rz.tstop])
                 for ptime in ptimes:
                     ax.axvline(ptime, ls='--', color='g')
+            # Add horizontal lines for the planning and caution limits
+            # or the limits for the focal plane model
+            if self.msid == msid:
+                if msid == "fptemp":
+                    pass
+                else:
+                    ax.axhline(self.yellow[self.name], linestyle='-', color='y',
+                               linewidth=2.0)
+                    ax.axhline(self.yellow[self.name] - self.margin[self.name], 
+                               linestyle='--', color='y', linewidth=2.0)
             filename = msid + '_valid.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)
@@ -688,7 +699,7 @@ class ACISThermalCheck(object):
                 ax.hist(diff / scale, bins=50, log=(histscale == 'log'))
                 if msid == self.msid and len(self.hist_limit) == 2 and ok2.any():
                     ax.hist(diff2 / scale, bins=50, log=(histscale == 'log'),
-                            color = 'red')
+                            color='red')
                 ax.set_title(msid.upper() + ' residuals: data - model')
                 ax.set_xlabel(labels[msid])
                 fig.subplots_adjust(bottom=0.18)

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -7,6 +7,16 @@ import numpy as np
 from scipy import misc
 import tempfile
 from .main import ACISThermalCheck
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--answer_store",
+                     help="Generate new answers, but don't test. "
+                          "Argument is the directory to store the answers to.")
+
+@pytest.fixture()
+def answer_store(request):
+    return request.config.getoption('--answer_store')
 
 months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
           "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -202,10 +202,10 @@ def compare_results(name, load_week, out_dir):
     old_tlm = old_results['tlm']
     tlm_keys = set(list(new_tlm.dtype.names)+list(old_tlm.dtype.names))
     for k in tlm_keys:
-        if k not in new_pred:
+        if k not in new_tlm:
             print("WARNING in tlm: '%s' in old answer but not new. Answers should be updated." % k)
             continue
-        if k not in old_pred:
+        if k not in old_tlm:
             print("WARNING in tlm: '%s' in new answer but not old. Answers should be updated." % k)
             continue
         assert_array_equal(new_tlm[k], old_tlm[k])

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -65,7 +65,7 @@ class TestArgs(object):
             year = 2000 + int(load_week[5:7])
             month = months.index(load_week[:3])+1
             day = int(load_week[3:5])
-            run_start = datetime.datetime(year, month, day).strftime("%Y:%j:%H:%M:%S")
+            run_start = datetime(year, month, day).strftime("%Y:%j:%H:%M:%S")
         self.run_start = run_start
         self.outdir = outdir
         # load_week sets the bsdir

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -87,10 +87,26 @@ class TestArgs(object):
         self.model_spec = model_spec
         self.version = None
 
-def load_test_template(msid, name, model_spec, load_week,
+def run_test_arrays(msid, name, model_path, atc_args, generate_answers,
+                    exclude_images=None):
+    for load_week in normal_loads:
+        load_test_template(msid, name, model_path, load_week, atc_args,
+                           generate_answers, interrupt=False,
+                           exclude_images=exclude_images)
+    for load_week in too_loads:
+        load_test_template(msid, name, model_path, load_week, atc_args,
+                           generate_answers, interrupt=True,
+                           exclude_images=exclude_images)
+    for load_week in stop_loads:
+        load_test_template(msid, name, model_path, load_week, atc_args,
+                           generate_answers, interrupt=True, 
+                           exclude_images=exclude_images)
+
+def load_test_template(msid, name, model_path, load_week,
                        atc_args, generate_answers, run_start=None,
                        state_builder='sql', interrupt=False,
                        cmd_states_db="sybase", exclude_images=None):
+    model_spec = os.path.join(model_path, "%s_model_spec.json" % name)
     if generate_answers is not None:
         generate_answers = os.path.join(os.path.abspath(generate_answers), 
                                         name, load_week)

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -170,12 +170,26 @@ def compare_results(name, load_week, out_dir):
     # Compare predictions
     new_pred = new_results["pred"]
     old_pred = old_results["pred"]
-    for k in new_pred:
+    pred_keys = set(list(new_pred.keys())+list(old_pred.keys()))
+    for k in pred_keys:
+        if k not in new_pred:
+            print("WARNING : '%s' in old answer but not new. Answers should be updated." % k)
+            continue
+        if k not in old_pred:
+            print("WARNING : '%s' in new answer but not old. Answers should be updated." % k)
+            continue
         assert_array_equal(new_pred[k], old_pred[k])
     # Compare telemetry
     new_tlm = new_results['tlm']
     old_tlm = old_results['tlm']
-    for k in new_tlm.dtype.names:
+    tlm_keys = set(list(new_tlm.dtype.names)+list(old_tlm.dtype.names))
+    for k in tlm_keys:
+        if k not in new_pred:
+            print("WARNING : '%s' in old answer but not new. Answers should be updated." % k)
+            continue
+        if k not in old_pred:
+            print("WARNING : '%s' in new answer but not old. Answers should be updated." % k)
+            continue
         assert_array_equal(new_tlm[k], old_tlm[k])
     # Compare
     for prefix in ("temperatures", "states"):
@@ -269,8 +283,16 @@ def compare_images(msid, name, load_week, out_dir):
     """
     images = build_image_list(msid)
     for image in images:
-        new_image = misc.imread(os.path.join(out_dir, image))
-        old_image = misc.imread(os.path.join(test_data_dir, name, load_week, image))
+        new_path = os.path.join(out_dir, image)
+        old_path = os.path.join(test_data_dir, name, load_week, image)
+        if not os.path.exists(old_path):
+            print("WARNING: Image %s has new answer but not old. Answers should be updated." % image)
+            continue
+        if not os.path.exists(new_path):
+            print("WARNING: Image %s has old answer but not new. Answers should be updated." % image)
+            continue
+        new_image = misc.imread(new_path)
+        old_image = misc.imread(old_path)
         assert_array_equal(new_image, old_image)
 
 def copy_new_images(msid, name, out_dir, answer_dir):

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -308,7 +308,13 @@ def build_image_list(msid):
     A simple function to build the list of images that will
     be compared for a particular ``msid``.
     """
-    images = ["%s.png" % msid, "pow_sim.png"]
+    images = ["pow_sim.png", "roll.png"]
+    if msid == "fptemp":
+        images += ["fptempM120toM112.png",
+                   "fptempM120toM119.png",
+                   "fptempM120toM90.png"]
+    else:
+        images.append("%s.png" % msid)
     for prefix in (msid, "pitch", "roll", "tscpos"):
         images += ["%s_valid.png" % prefix,
                    "%s_valid_hist_lin.png" % prefix,

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -92,7 +92,10 @@ def load_test_template(msid, name, model_spec, load_week,
                        state_builder='sql', interrupt=False,
                        cmd_states_db="sybase", exclude_images=None):
     if generate_answers is not None:
-        generate_answers = os.path.abspath(generate_answers)
+        generate_answers = os.path.join(os.path.abspath(generate_answers), 
+                                        name, load_week)
+        if not os.path.exists(generate_answers):
+            os.makedirs(generate_answers)
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
@@ -230,14 +233,9 @@ def copy_new_results(name, out_dir, answer_dir):
     answer_dir : string
         The path to the directory to which to copy the files.
     """
-    if not os.path.exists(answer_dir):
-        os.mkdir(answer_dir)
-    adir = os.path.join(answer_dir, name)
-    if not os.path.exists(adir):
-        os.mkdir(adir)
     for fn in ('validation_data.pkl', 'states.dat', 'temperatures.dat'):
         fromfile = os.path.join(out_dir, fn)
-        tofile = os.path.join(adir, fn)
+        tofile = os.path.join(answer_dir, fn)
         shutil.copyfile(fromfile, tofile)
 
 def run_answer_test(name, load_week, out_dir, answer_dir):
@@ -307,6 +305,7 @@ def compare_images(msid, name, load_week, out_dir, exclude_images):
     for image in images:
         if image in exclude_images:
             continue
+        print(image)
         new_path = os.path.join(out_dir, image)
         old_path = os.path.join(test_data_dir, name, load_week, image)
         if not os.path.exists(old_path):
@@ -341,10 +340,7 @@ def copy_new_images(msid, name, out_dir, answer_dir):
     images = build_image_list(msid)
     for image in images:
         fromfile = os.path.join(out_dir, image)
-        adir = os.path.join(answer_dir, name)
-        if not os.path.exists(adir):
-            os.mkdir(adir)
-        tofile = os.path.join(adir, image)
+        tofile = os.path.join(answer_dir, image)
         shutil.copyfile(fromfile, tofile)
 
 def run_image_test(msid, name, load_week, out_dir, answer_dir, 

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -159,7 +159,7 @@ data_dtype = {'temperatures': {'names': ('time', 'date', 'temperature'),
 def exception_catcher(test, old, new, data_type):
     try:
         test(old, new)
-    except:
+    except AssertionError:
         raise AssertionError("%s are not the same!" % data_type)
 
 def compare_data_files(prefix, name, load_week, out_dir):

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -21,7 +21,7 @@ test_loads = [
          "MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"
 ]
 
-class TestOpts(object):
+class TestArgs(object):
     """
     A mock-up of a command-line parser object to be used with
     ACISThermalCheck testing.
@@ -109,9 +109,14 @@ def run_model(name, msid_check, model_spec, load_week, run_start=None,
         "sybase" or "sqlite". Default: "sybase"
     """
     out_dir = name+"_test"
-    msid_opts = TestOpts(name, run_start, out_dir, model_spec=model_spec,
-                         load_week=load_week, cmd_states_db=cmd_states_db)
-    msid_check.driver(msid_opts)
+    args = TestArgs(name, run_start, out_dir, model_spec=model_spec,
+                    load_week=load_week, cmd_states_db=cmd_states_db)
+    state_builder = make_state_builder(args.state_builder, args)
+    msid_check = ACISThermalCheck("1deamzt", "dea", MSID, YELLOW,
+                                   MARGIN, VALIDATION_LIMITS,
+                                   HIST_LIMIT, calc_model)
+
+    msid_check.driver(args, state_builder)
     return msid_check.msid, out_dir
 
 # Large, multi-layer dictionary which encodes the datatypes for the

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -6,6 +6,7 @@ import shutil
 import numpy as np
 from scipy import misc
 import tempfile
+from .main import ACISThermalCheck
 
 # This directory is currently where the thermal model
 # "gold standard" answers live.
@@ -71,18 +72,18 @@ class TestArgs(object):
         self.model_spec = model_spec
         self.version = None
 
-def load_test_template(name, msid_check, model_spec, load_week,
+def load_test_template(name, msid, model_spec, load_week,
                        generate_answers):
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
-    msid, out_dir = run_model(name, msid_check, model_spec, load_week)
+    msid, out_dir = run_model(name, msid, model_spec, load_week)
     run_answer_test(name, load_week, out_dir, generate_answers)
     run_image_test(msid, name, load_week, out_dir, generate_answers)
     os.chdir(curdir)
     shutil.rmtree(tmpdir)
 
-def run_model(name, msid_check, model_spec, load_week, run_start=None,
+def run_model(name, msid, model_spec, load_week, run_start=None,
               cmd_states_db='sybase'):
     """
     Function to run a thermal model for a test.
@@ -111,8 +112,7 @@ def run_model(name, msid_check, model_spec, load_week, run_start=None,
     out_dir = name+"_test"
     args = TestArgs(name, run_start, out_dir, model_spec=model_spec,
                     load_week=load_week, cmd_states_db=cmd_states_db)
-    state_builder = make_state_builder(args.state_builder, args)
-    msid_check = ACISThermalCheck("1deamzt", "dea", MSID, YELLOW,
+    msid_check = ACISThermalCheck(msid, name, MSID, YELLOW,
                                    MARGIN, VALIDATION_LIMITS,
                                    HIST_LIMIT, calc_model)
 

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -202,10 +202,10 @@ def compare_results(name, load_week, out_dir):
     old_tlm = old_results['tlm']
     tlm_keys = set(list(new_tlm.dtype.names)+list(old_tlm.dtype.names))
     for k in tlm_keys:
-        if k not in new_tlm:
+        if k not in new_tlm.dtype.names:
             print("WARNING in tlm: '%s' in old answer but not new. Answers should be updated." % k)
             continue
-        if k not in old_tlm:
+        if k not in old_tlm.dtype.names:
             print("WARNING in tlm: '%s' in new answer but not old. Answers should be updated." % k)
             continue
         assert_array_equal(new_tlm[k], old_tlm[k])

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -8,6 +8,9 @@ from scipy import misc
 import tempfile
 from .main import ACISThermalCheck
 
+months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+          "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]
+
 # This directory is currently where the thermal model
 # "gold standard" answers live.
 test_data_dir = "/data/acis/thermal_model_tests"
@@ -32,10 +35,11 @@ class TestArgs(object):
     name : string
         The "short" name of the model, referring to the component
         it models the temperature for, e.g. "dea", "dpa", "psmc".
-    run_start : string
-        The run start time in YYYY:DOY:HH:MM:SS.SSS format.
     outdir : string
         The path to the output directory.
+    run_start : string, optional
+        The run start time in YYYY:DOY:HH:MM:SS.SSS format. If not
+        specified, one will be created 3 days prior to the model run.
     model_spec : string, optional
         The path to the model specification JSON file. If not provided,
         the default one will be used.
@@ -52,10 +56,16 @@ class TestArgs(object):
         The mode of database access for the commanded states database.
         "sybase" or "sqlite". Default: "sybase"
     """
-    def __init__(self, name, run_start, outdir, model_spec=None,
-                 load_week=None, days=21.0, T_init=None, 
+    def __init__(self, name, outdir, run_start=None, model_spec=None,
+                 load_week=None, days=21.0, T_init=None,
                  cmd_states_db='sybase'):
+        from datetime import datetime
         self.load_week = load_week
+        if run_start is None:
+            year = 2000 + int(load_week[5:7])
+            month = months.index(load_week[:3])+1
+            day = int(load_week[3:5])
+            run_start = datetime.datetime(year, month, day).strftime("%Y:%j:%H:%M:%S")
         self.run_start = run_start
         self.outdir = outdir
         # load_week sets the bsdir

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -160,8 +160,6 @@ def exception_catcher(test, old, new, data_type):
     try:
         test(old, new)
     except AssertionError:
-        import traceback
-        traceback.print_exc()
         raise AssertionError("%s are not the same!" % data_type)
 
 def compare_data_files(prefix, name, load_week, out_dir):

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -10,6 +10,16 @@ from scipy import misc
 # "gold standard" answers live.
 test_data_dir = "/data/acis/thermal_model_tests"
 
+# Loads for regression testing
+test_loads = [
+# normal loads
+         "MAR0617A", "MAR2017E", "JUL3117B", "SEP0417A",
+# TOOs
+         "MAR1517B", "JUL2717A", "AUG2517C", "AUG3017A",
+# STOPs
+         "MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"
+]
+
 class TestOpts(object):
     """
     A mock-up of a command-line parser object to be used with

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -132,17 +132,16 @@ class RegressionTester(object):
             atc_kwargs = {}
         self.atc_kwargs = atc_kwargs
 
-    def run_test_arrays(self, atc_args, generate_answers,
-                        exclude_images=None):
+    def run_test_arrays(self, generate_answers, exclude_images=None):
         for load_week in normal_loads:
-            self.load_test_template(load_week, atc_args, generate_answers,
-                                    interrupt=False, exclude_images=exclude_images)
+            self.load_test_template(load_week, generate_answers, interrupt=False, 
+                                    exclude_images=exclude_images)
         for load_week in too_loads:
-            self.load_test_template(load_week, atc_args, generate_answers,
-                                    interrupt=True, exclude_images=exclude_images)
+            self.load_test_template(load_week, generate_answers, interrupt=True, 
+                                    exclude_images=exclude_images)
         for load_week in stop_loads:
-            self.load_test_template(load_week, atc_args, generate_answers,
-                                    interrupt=True, exclude_images=exclude_images)
+            self.load_test_template(load_week, generate_answers, interrupt=True, 
+                                    exclude_images=exclude_images)
 
     def load_test_template(self, load_week, generate_answers, run_start=None,
                            state_builder='sql', interrupt=False, cmd_states_db="sybase",

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -37,9 +37,6 @@ class TestArgs(object):
 
     Parameters
     ----------
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
     outdir : string
         The path to the output directory.
     run_start : string, optional
@@ -68,7 +65,7 @@ class TestArgs(object):
     verbose : integer, optional
         The verbosity of the output. Default: 0
     """
-    def __init__(self, name, outdir, run_start=None, model_spec=None,
+    def __init__(self, outdir, run_start=None, model_spec=None,
                  load_week=None, days=21.0, T_init=None, interrupt=False,
                  state_builder='sql', cmd_states_db='sybase', verbose=0):
         from datetime import datetime
@@ -97,56 +94,15 @@ class TestArgs(object):
         self.model_spec = model_spec
         self.version = None
 
-def run_test_arrays(msid, name, model_path, atc_args, generate_answers,
-                    exclude_images=None):
-    for load_week in normal_loads:
-        load_test_template(msid, name, model_path, load_week, atc_args,
-                           generate_answers, interrupt=False,
-                           exclude_images=exclude_images)
-    for load_week in too_loads:
-        load_test_template(msid, name, model_path, load_week, atc_args,
-                           generate_answers, interrupt=True,
-                           exclude_images=exclude_images)
-    for load_week in stop_loads:
-        load_test_template(msid, name, model_path, load_week, atc_args,
-                           generate_answers, interrupt=True, 
-                           exclude_images=exclude_images)
-
-def load_test_template(msid, name, model_path, load_week,
-                       atc_args, generate_answers, run_start=None,
-                       state_builder='sql', interrupt=False,
-                       cmd_states_db="sybase", exclude_images=None):
-    model_spec = os.path.join(model_path, "%s_model_spec.json" % name)
-    if generate_answers is not None:
-        generate_answers = os.path.join(os.path.abspath(generate_answers), 
-                                        name, load_week)
-        if not os.path.exists(generate_answers):
-            os.makedirs(generate_answers)
-    tmpdir = tempfile.mkdtemp()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
-    out_dir = name+"_test"
-    args = TestArgs(name, out_dir, run_start=run_start, model_spec=model_spec,
-                    load_week=load_week, interrupt=interrupt, 
-                    cmd_states_db=cmd_states_db, state_builder=state_builder)
-    msid_check = ACISThermalCheck(msid, name, atc_args[0], atc_args[1],
-                                  atc_args[2], args)
-    msid_check.run()
-    run_answer_test(name, load_week, out_dir, generate_answers)
-    run_image_test(msid, name, load_week, out_dir, generate_answers, 
-                   exclude_images)
-    os.chdir(curdir)
-    shutil.rmtree(tmpdir)
-
 # Large, multi-layer dictionary which encodes the datatypes for the
 # different quantities that are being checked against.
 data_dtype = {'temperatures': {'names': ('time', 'date', 'temperature'),
                                'formats': ('f8', 'S21', 'f8')
                               },
               'states': {'names': ('ccd_count', 'clocking', 'datestart',
-                                   'datestop', 'dec', 'dither', 'fep_count', 
-                                   'hetg', 'letg', 'obsid', 'pcad_mode', 
-                                   'pitch', 'power_cmd', 'q1', 'q2', 'q3', 
+                                   'datestop', 'dec', 'dither', 'fep_count',
+                                   'hetg', 'letg', 'obsid', 'pcad_mode',
+                                   'pitch', 'power_cmd', 'q1', 'q2', 'q3',
                                    'q4', 'ra', 'roll', 'si_mode', 'simfa_pos',
                                    'simpos', 'trans_keys'),
                          'formats': ('i4', 'i4', 'S21', 'S21', 'f8', 'S4',
@@ -162,261 +118,282 @@ def exception_catcher(test, old, new, data_type):
     except AssertionError:
         raise AssertionError("%s are not the same!" % data_type)
 
-def compare_data_files(prefix, name, load_week, out_dir):
-    """
-    This function compares the "gold standard" data with the current
-    test run's data for the .dat files produced in the thermal model
-    run. Called by ``compare_results``.
+class RegressionTester(object):
+    def __init__(self, msid, name, model_path):
+        self.msid = msid
+        self.name = name
+        self.model_path = model_path
+        self.model_spec = os.path.join(self.model_path, "%s_model_spec.json" % self.name)
 
-    Parameters
-    ----------
-    prefix : string
-        The prefix of the file, "temperatures" or "states".
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    load_week : string, optional
-        The load week to be tested, in a format like "MAY2016". If not
-        provided, it is assumed that a full set of initial states will
-        be supplied.
-    out_dir : string
-        The path to the output directory.
-    """
-    fn = prefix+".dat"
-    new_fn = os.path.join(out_dir, fn)
-    old_fn = os.path.join(test_data_dir, name, load_week, fn)
-    new_data = np.loadtxt(new_fn, skiprows=1, dtype=data_dtype[prefix])
-    old_data = np.loadtxt(old_fn, skiprows=1, dtype=data_dtype[prefix])
-    # Compare test run data to gold standard. Since we're loading from
-    # ASCII text files here, floating-point comparisons will be different
-    # at machine precision, others will be exact.
-    for k, dt in new_data.dtype.descr:
-        if 'f' in dt:
-            exception_catcher(assert_allclose, new_data[k], old_data[k],
-                              "Prediction arrays for %s" % k)
+    def run_test_arrays(self, atc_args, generate_answers,
+                        exclude_images=None, atc_kwargs=None):
+        for load_week in normal_loads:
+            self.load_test_template(load_week, atc_args, generate_answers,
+                                    interrupt=False, exclude_images=exclude_images,
+                                    atc_kwargs=atc_kwargs)
+        for load_week in too_loads:
+            self.load_test_template(load_week, atc_args, generate_answers,
+                                    interrupt=True, exclude_images=exclude_images,
+                                    atc_kwargs=atc_kwargs)
+        for load_week in stop_loads:
+            self.load_test_template(load_week, atc_args, generate_answers,
+                                    interrupt=True, exclude_images=exclude_images,
+                                    atc_kwargs=atc_kwargs)
+
+    def load_test_template(self, load_week, atc_args, generate_answers, run_start=None,
+                           state_builder='sql', interrupt=False, cmd_states_db="sybase",
+                           exclude_images=None, atc_kwargs=None):
+        if generate_answers is not None:
+            generate_answers = os.path.join(os.path.abspath(generate_answers),
+                                            self.name, load_week)
+            if not os.path.exists(generate_answers):
+                os.makedirs(generate_answers)
+        if atc_kwargs is None:
+            atc_kwargs = {}
+        tmpdir = tempfile.mkdtemp()
+        curdir = os.getcwd()
+        os.chdir(tmpdir)
+        out_dir = self.name+"_test"
+        args = TestArgs(out_dir, run_start=run_start, model_spec=self.model_spec,
+                        load_week=load_week, interrupt=interrupt,
+                        cmd_states_db=cmd_states_db, state_builder=state_builder)
+        msid_check = ACISThermalCheck(self.msid, self.name, atc_args[0], atc_args[1],
+                                      atc_args[2], args, **atc_kwargs)
+        msid_check.run()
+        self.run_answer_test(load_week, out_dir, generate_answers)
+        self.run_image_test(load_week, out_dir, generate_answers,
+                            exclude_images)
+        os.chdir(curdir)
+        shutil.rmtree(tmpdir)
+
+    def run_answer_test(self, load_week, out_dir, answer_dir):
+        """
+        This function runs the answer test in one of two modes:
+        either comparing the answers from this test to the "gold
+        standard" answers or to simply run the model to generate
+        answers.
+
+        Parameters
+        ----------
+        load_week : string, optional
+            The load week to be tested, in a format like "MAY2016". If not
+            provided, it is assumed that a full set of initial states will
+            be supplied.
+        out_dir : string
+            The path to the output directory.
+        answer_dir : string
+            The path to the directory to which to copy the files. Is None
+            if this is a test run, is an actual directory if we are simply
+            generating answers.
+        """
+        out_dir = os.path.abspath(out_dir)
+        if not answer_dir:
+            self.compare_results(load_week, out_dir)
         else:
-            exception_catcher(assert_array_equal, new_data[k], old_data[k],
-                              "Prediction arrays for %s" % k)
+            self.copy_new_results(out_dir, answer_dir)
 
-def compare_results(name, load_week, out_dir):
-    """
-    This function compares the "gold standard" data with the current
-    test run's data.
+    def run_image_test(self, load_week, out_dir, answer_dir,
+                       exclude_images):
+        """
+        This function runs the image answer test in one of two modes:
+        either comparing the image answers from this test to the "gold
+        standard" answers or to simply run the model to generate image
+        answers.
 
-    Parameters
-    ----------
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    load_week : string, optional
-        The load week to be tested, in a format like "MAY2016". If not
-        provided, it is assumed that a full set of initial states will
-        be supplied.
-    out_dir : string
-        The path to the output directory.
-    """
-    # First load the answers from the pickle files, both gold standard
-    # and current
-    new_answer_file = os.path.join(out_dir, "validation_data.pkl")
-    new_results = pickle.load(open(new_answer_file, "rb"))
-    old_answer_file = os.path.join(test_data_dir, name, load_week,
-                                   "validation_data.pkl")
-    old_results = pickle.load(open(old_answer_file, "rb"))
-    # Compare predictions
-    new_pred = new_results["pred"]
-    old_pred = old_results["pred"]
-    pred_keys = set(list(new_pred.keys())+list(old_pred.keys()))
-    for k in pred_keys:
-        if k not in new_pred:
-            print("WARNING in pred: '%s' in old answer but not new. Answers should be updated." % k)
-            continue
-        if k not in old_pred:
-            print("WARNING in pred: '%s' in new answer but not old. Answers should be updated." % k)
-            continue
-        exception_catcher(assert_array_equal, new_pred[k], old_pred[k],
-                          "Validation model arrays for %s" % k)
-    # Compare telemetry
-    new_tlm = new_results['tlm']
-    old_tlm = old_results['tlm']
-    tlm_keys = set(list(new_tlm.dtype.names)+list(old_tlm.dtype.names))
-    for k in tlm_keys:
-        if k not in new_tlm.dtype.names:
-            print("WARNING in tlm: '%s' in old answer but not new. Answers should be updated." % k)
-            continue
-        if k not in old_tlm.dtype.names:
-            print("WARNING in tlm: '%s' in new answer but not old. Answers should be updated." % k)
-            continue
-        exception_catcher(assert_array_equal, new_tlm[k], old_tlm[k], 
-                          "Validation telemetry arrays for %s" % k)
-    # Compare
-    for prefix in ("temperatures", "states"):
-        compare_data_files(prefix, name, load_week, out_dir)
+        Parameters
+        ----------
+        load_week : string, optional
+            The load week to be tested, in a format like "MAY2016". If not
+            provided, it is assumed that a full set of initial states will
+            be supplied.
+        out_dir : string
+            The path to the output directory.
+        answer_dir : string
+            The path to the directory to which to copy the files. Is None
+            if this is a test run, is an actual directory if we are simply
+            generating answers.
+        exclude_images : list of strings
+            A list of images to be excluded from the comparison tests. Default: None
+        """
+        if exclude_images is None:
+            exclude_images = []
+        out_dir = os.path.abspath(out_dir)
+        if not answer_dir:
+            self.compare_images(load_week, out_dir, exclude_images)
+        else:
+            self.copy_new_images(out_dir, answer_dir)
 
-def copy_new_results(out_dir, answer_dir):
-    """
-    This function copies the pickle files and the .dat files
-    generated in this test run to a directory specified by the
-    user, typically for inspection and for possible updating of
-    the "gold standard" answers.
+    def compare_results(self, load_week, out_dir):
+        """
+        This function compares the "gold standard" data with the current
+        test run's data.
 
-    Parameters
-    ----------
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    out_dir : string
-        The path to the output directory.
-    answer_dir : string
-        The path to the directory to which to copy the files.
-    """
-    for fn in ('validation_data.pkl', 'states.dat', 'temperatures.dat'):
-        fromfile = os.path.join(out_dir, fn)
-        tofile = os.path.join(answer_dir, fn)
-        shutil.copyfile(fromfile, tofile)
+        Parameters
+        ----------
+        load_week : string, optional
+            The load week to be tested, in a format like "MAY2016". If not
+            provided, it is assumed that a full set of initial states will
+            be supplied.
+        out_dir : string
+            The path to the output directory.
+        """
+        # First load the answers from the pickle files, both gold standard
+        # and current
+        new_answer_file = os.path.join(out_dir, "validation_data.pkl")
+        new_results = pickle.load(open(new_answer_file, "rb"))
+        old_answer_file = os.path.join(test_data_dir, self.name, load_week,
+                                       "validation_data.pkl")
+        old_results = pickle.load(open(old_answer_file, "rb"))
+        # Compare predictions
+        new_pred = new_results["pred"]
+        old_pred = old_results["pred"]
+        pred_keys = set(list(new_pred.keys())+list(old_pred.keys()))
+        for k in pred_keys:
+            if k not in new_pred:
+                print("WARNING in pred: '%s' in old answer but not new. Answers should be updated." % k)
+                continue
+            if k not in old_pred:
+                print("WARNING in pred: '%s' in new answer but not old. Answers should be updated." % k)
+                continue
+            exception_catcher(assert_array_equal, new_pred[k], old_pred[k],
+                              "Validation model arrays for %s" % k)
+        # Compare telemetry
+        new_tlm = new_results['tlm']
+        old_tlm = old_results['tlm']
+        tlm_keys = set(list(new_tlm.dtype.names)+list(old_tlm.dtype.names))
+        for k in tlm_keys:
+            if k not in new_tlm.dtype.names:
+                print("WARNING in tlm: '%s' in old answer but not new. Answers should be updated." % k)
+                continue
+            if k not in old_tlm.dtype.names:
+                print("WARNING in tlm: '%s' in new answer but not old. Answers should be updated." % k)
+                continue
+            exception_catcher(assert_array_equal, new_tlm[k], old_tlm[k],
+                              "Validation telemetry arrays for %s" % k)
+        # Compare
+        for prefix in ("temperatures", "states"):
+            self.compare_data_files(prefix, load_week, out_dir)
 
-def run_answer_test(name, load_week, out_dir, answer_dir):
-    """
-    This function runs the answer test in one of two modes:
-    either comparing the answers from this test to the "gold
-    standard" answers or to simply run the model to generate
-    answers.
+    def compare_data_files(self, prefix, load_week, out_dir):
+        """
+        This function compares the "gold standard" data with the current
+        test run's data for the .dat files produced in the thermal model
+        run. Called by ``compare_results``.
 
-    Parameters
-    ----------
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    load_week : string, optional
-        The load week to be tested, in a format like "MAY2016". If not
-        provided, it is assumed that a full set of initial states will
-        be supplied.
-    out_dir : string
-        The path to the output directory.
-    answer_dir : string
-        The path to the directory to which to copy the files. Is None
-        if this is a test run, is an actual directory if we are simply
-        generating answers.
-    """
-    out_dir = os.path.abspath(out_dir)
-    if not answer_dir:
-        compare_results(name, load_week, out_dir)
-    else:
-        copy_new_results(out_dir, answer_dir)
+        Parameters
+        ----------
+        prefix : string
+            The prefix of the file, "temperatures" or "states".
+        load_week : string, optional
+            The load week to be tested, in a format like "MAY2016". If not
+            provided, it is assumed that a full set of initial states will
+            be supplied.
+        out_dir : string
+            The path to the output directory.
+        """
+        fn = prefix+".dat"
+        new_fn = os.path.join(out_dir, fn)
+        old_fn = os.path.join(test_data_dir, self.name, load_week, fn)
+        new_data = np.loadtxt(new_fn, skiprows=1, dtype=data_dtype[prefix])
+        old_data = np.loadtxt(old_fn, skiprows=1, dtype=data_dtype[prefix])
+        # Compare test run data to gold standard. Since we're loading from
+        # ASCII text files here, floating-point comparisons will be different
+        # at machine precision, others will be exact.
+        for k, dt in new_data.dtype.descr:
+            if 'f' in dt:
+                exception_catcher(assert_allclose, new_data[k], old_data[k],
+                                  "Prediction arrays for %s" % k)
+            else:
+                exception_catcher(assert_array_equal, new_data[k], old_data[k],
+                                  "Prediction arrays for %s" % k)
 
-def build_image_list(msid):
-    """
-    A simple function to build the list of images that will
-    be compared for a particular ``msid``.
-    """
-    images = ["pow_sim.png", "roll.png"]
-    if msid == "fptemp":
-        images += ["fptempM120toM112.png",
-                   "fptempM120toM119.png",
-                   "fptempM120toM90.png"]
-    else:
-        images.append("%s.png" % msid)
-    for prefix in (msid, "pitch", "roll", "tscpos"):
-        images += ["%s_valid.png" % prefix,
-                   "%s_valid_hist_lin.png" % prefix,
-                   "%s_valid_hist_log.png" % prefix]
-    return images
+    def copy_new_results(self, out_dir, answer_dir):
+        """
+        This function copies the pickle files and the .dat files
+        generated in this test run to a directory specified by the
+        user, typically for inspection and for possible updating of
+        the "gold standard" answers.
 
-def compare_images(msid, name, load_week, out_dir, exclude_images):
-    """
-    This function compares two images using SciPy's
-    ``imread`` function to convert images to NumPy
-    integer arrays and comparing them.
+        Parameters
+        ----------
+        out_dir : string
+            The path to the output directory.
+        answer_dir : string
+            The path to the directory to which to copy the files.
+        """
+        for fn in ('validation_data.pkl', 'states.dat', 'temperatures.dat'):
+            fromfile = os.path.join(out_dir, fn)
+            tofile = os.path.join(answer_dir, fn)
+            shutil.copyfile(fromfile, tofile)
 
-    Parameters
-    ----------
-    msid : string
-        The MSID that is being modeled.
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    load_week : string, optional
-        The load week to be tested, in a format like "MAY2016". If not
-        provided, it is assumed that a full set of initial states will
-        be supplied.
-    out_dir : string
-        The path to the output directory.
-    exclude_images : list of strings
-        A list of images to be excluded from the comparison tests. Default: None
-    """
-    images = build_image_list(msid)
-    for image in images:
-        if image in exclude_images:
-            continue
-        new_path = os.path.join(out_dir, image)
-        old_path = os.path.join(test_data_dir, name, load_week, image)
-        if not os.path.exists(old_path):
-            print("WARNING: Image %s has new answer but not old. Answers should be updated." % image)
-            continue
-        if not os.path.exists(new_path):
-            print("WARNING: Image %s has old answer but not new. Answers should be updated." % image)
-            continue
-        new_image = misc.imread(new_path)
-        old_image = misc.imread(old_path)
-        exception_catcher(assert_array_equal, new_image, old_image,
-                          "Images for %s" % image)
+    def build_image_list(self):
+        """
+        A simple function to build the list of images that will
+        be compared for a particular ``msid``.
+        """
+        images = ["pow_sim.png", "roll.png"]
+        if self.msid == "fptemp":
+            images += ["fptempM120toM112.png",
+                       "fptempM120toM119.png",
+                       "fptempM120toM90.png"]
+        else:
+            images.append("%s.png" % self.msid)
+        for prefix in (self.msid, "pitch", "roll", "tscpos"):
+            images += ["%s_valid.png" % prefix,
+                       "%s_valid_hist_lin.png" % prefix,
+                       "%s_valid_hist_log.png" % prefix]
+        return images
 
-def copy_new_images(msid, out_dir, answer_dir):
-    """
-    This function copies the image files generated in this test
-    run to a directory specified by the user, typically for
-    inspection and for possible updating of the "gold standard"
-    answers.
+    def compare_images(self, load_week, out_dir, exclude_images):
+        """
+        This function compares two images using SciPy's
+        ``imread`` function to convert images to NumPy
+        integer arrays and comparing them.
 
-    Parameters
-    ----------
-    msid : string
-        The MSID that is being modeled.
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    out_dir : string
-        The path to the output directory.
-    answer_dir : string
-        The path to the directory to which to copy the files.
-    """
-    images = build_image_list(msid)
-    for image in images:
-        fromfile = os.path.join(out_dir, image)
-        tofile = os.path.join(answer_dir, image)
-        shutil.copyfile(fromfile, tofile)
+        Parameters
+        ----------
+        load_week : string, optional
+            The load week to be tested, in a format like "MAY2016". If not
+            provided, it is assumed that a full set of initial states will
+            be supplied.
+        out_dir : string
+            The path to the output directory.
+        exclude_images : list of strings
+            A list of images to be excluded from the comparison tests. Default: None
+        """
+        images = self.build_image_list()
+        for image in images:
+            if image in exclude_images:
+                continue
+            new_path = os.path.join(out_dir, image)
+            old_path = os.path.join(test_data_dir, self.name, load_week, image)
+            if not os.path.exists(old_path):
+                print("WARNING: Image %s has new answer but not old. Answers should be updated." % image)
+                continue
+            if not os.path.exists(new_path):
+                print("WARNING: Image %s has old answer but not new. Answers should be updated." % image)
+                continue
+            new_image = misc.imread(new_path)
+            old_image = misc.imread(old_path)
+            exception_catcher(assert_array_equal, new_image, old_image,
+                              "Images for %s" % image)
 
-def run_image_test(msid, name, load_week, out_dir, answer_dir, 
-                   exclude_images):
-    """
-    This function runs the image answer test in one of two modes:
-    either comparing the image answers from this test to the "gold
-    standard" answers or to simply run the model to generate image
-    answers.
+    def copy_new_images(self, out_dir, answer_dir):
+        """
+        This function copies the image files generated in this test
+        run to a directory specified by the user, typically for
+        inspection and for possible updating of the "gold standard"
+        answers.
 
-    Parameters
-    ----------
-    msid : string
-        The MSID that is being modeled.
-    name : string
-        The "short" name of the model, referring to the component
-        it models the temperature for, e.g. "dea", "dpa", "psmc".
-    load_week : string, optional
-        The load week to be tested, in a format like "MAY2016". If not
-        provided, it is assumed that a full set of initial states will
-        be supplied.
-    out_dir : string
-        The path to the output directory.
-    answer_dir : string
-        The path to the directory to which to copy the files. Is None
-        if this is a test run, is an actual directory if we are simply
-        generating answers. 
-    exclude_images : list of strings
-        A list of images to be excluded from the comparison tests. Default: None
-    """
-    if exclude_images is None:
-        exclude_images = []
-    out_dir = os.path.abspath(out_dir)
-    if not answer_dir:
-        compare_images(msid, name, load_week, out_dir, exclude_images)
-    else:
-        copy_new_images(msid, out_dir, answer_dir)
+        Parameters
+        ----------
+        out_dir : string
+            The path to the output directory.
+        answer_dir : string
+            The path to the directory to which to copy the files.
+        """
+        images = self.build_image_list()
+        for image in images:
+            fromfile = os.path.join(out_dir, image)
+            tofile = os.path.join(answer_dir, image)
+            shutil.copyfile(fromfile, tofile)

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -160,6 +160,8 @@ def exception_catcher(test, old, new, data_type):
     try:
         test(old, new)
     except AssertionError:
+        import traceback
+        traceback.print_exc()
         raise AssertionError("%s are not the same!" % data_type)
 
 def compare_data_files(prefix, name, load_week, out_dir):

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -73,18 +73,18 @@ class TestArgs(object):
         self.version = None
 
 def load_test_template(name, msid, model_spec, load_week,
-                       generate_answers):
+                       atc_args, generate_answers):
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
-    msid, out_dir = run_model(name, msid, model_spec, load_week)
+    out_dir = run_model(name, msid, model_spec, load_week, atc_args)
     run_answer_test(name, load_week, out_dir, generate_answers)
     run_image_test(msid, name, load_week, out_dir, generate_answers)
     os.chdir(curdir)
     shutil.rmtree(tmpdir)
 
-def run_model(name, msid, model_spec, load_week, run_start=None,
-              cmd_states_db='sybase'):
+def run_model(name, msid, model_spec, load_week, atc_args,
+              run_start=None, cmd_states_db='sybase'):
     """
     Function to run a thermal model for a test.
 
@@ -103,6 +103,8 @@ def run_model(name, msid, model_spec, load_week, run_start=None,
         The load week to be tested, in a format like "MAY2016". If not
         provided, it is assumed that a full set of initial states will
         be supplied.
+    atc_args : list
+        A list of objects to be passed as arguments to ACISThermalCheck.
     run_start : string, optional
         The run start time in YYYY:DOY:HH:MM:SS.SSS format. Default: None
     cmd_states_db : string, optional
@@ -112,12 +114,11 @@ def run_model(name, msid, model_spec, load_week, run_start=None,
     out_dir = name+"_test"
     args = TestArgs(name, run_start, out_dir, model_spec=model_spec,
                     load_week=load_week, cmd_states_db=cmd_states_db)
-    msid_check = ACISThermalCheck(msid, name, MSID, YELLOW,
-                                   MARGIN, VALIDATION_LIMITS,
-                                   HIST_LIMIT, calc_model)
+    msid_check = ACISThermalCheck(msid, name, atc_args[0], atc_args[1],
+                                  atc_args[2], atc_args[3], args)
 
-    msid_check.driver(args, state_builder)
-    return msid_check.msid, out_dir
+    msid_check.run()
+    return out_dir
 
 # Large, multi-layer dictionary which encodes the datatypes for the
 # different quantities that are being checked against.

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -356,10 +356,12 @@ def get_acis_limits(msid):
         cols = (3, 5)
 
     if os.path.exists(file_root):
+        mylog.info("Obtaining limits from local file.")
         f = open(os.path.join(file_root, limits_file), "r")
         lines = f.readlines()
         f.close()
     else:
+        mylog.info("Obtaining limits from remote file.")
         url = "http://cxc.cfa.harvard.edu/acis/"+limits_file
         u = requests.get(url)
         lines = u.text.split("\n")

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -346,14 +346,15 @@ def get_acis_limits(msid):
     if msid.startswith("tmp_"):
         url = "http://cxc.cfa.harvard.edu/acis/PMON/pmon_limits.txt"
         cols = (5, 6)
+        msid = "ADC_"+msid.upper()
     else:
-        url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+        url = "http://cxc.cfa.harvard.edu/acis/Thermal/MSID_Limits.txt"
         cols = (3, 5)
 
     u = requests.get(url)
 
     for line in u.text.split("\n"):
-        words = line.strip().split("\t")
+        words = line.strip().split()
         if len(words) > 1 and words[0] == msid.upper():
             yellow_hi = float(words[cols[0]])
             red_hi = float(words[cols[1]])

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -330,9 +330,9 @@ def make_state_builder(name, args):
 
 def get_acis_limits(msid):
     """
-    Get the current red and yellow hi limits for a given 
-    ACIS-related MSID, or the various limits for the 
-    focal plane temperature.
+    Get the current yellow hi limit and margin for a 
+    given ACIS-related MSID, or the various limits 
+    for the focal plane temperature.
 
     Parameters
     ----------
@@ -348,7 +348,13 @@ def get_acis_limits(msid):
         return fp_sens, acis_i, acis_s
 
     yellow_hi = None
-    red_hi = None
+
+    margin = {"1dpamzt": 2.0, 
+              "1deamzt": 2.0,
+              "1pdeaat": 4.5,
+              "tmp_fep1_mong": 2.0,
+              "tmp_fep1_actel": 2.0,
+              "tmp_bep_pcb": 2.0}
 
     pmon_file = "PMON/pmon_limits.txt"
     eng_file = "Thermal/MSID_Limits.txt"
@@ -379,7 +385,6 @@ def get_acis_limits(msid):
         words = line.strip().split()
         if len(words) > 1 and words[0] == msid.upper():
             yellow_hi = float(words[cols[0]])
-            red_hi = float(words[cols[1]])
             break
 
-    return yellow_hi, red_hi
+    return yellow_hi, margin[msid]

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -82,7 +82,8 @@ def plot_one(fig_id, x, y, linestyle='-',
              color='blue', xmin=None,
              xmax=None, ylim=None, 
              xlabel='', ylabel='', title='',
-             figsize=(7, 3.5)):
+             figsize=(7, 3.5), load_start=None,
+             width=None):
     """
     Plot one quantities with a date x-axis and a left
     y-axis.
@@ -134,10 +135,21 @@ def plot_one(fig_id, x, y, linestyle='-',
     ax.set_title(title)
     ax.grid()
 
+    if load_start is not None:
+        # Add a vertical line to mark the start time of the load
+        ax.axvline(load_start, linestyle='-', color='g', linewidth=2.0)
+
     Ska.Matplotlib.set_time_ticks(ax)
     [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
 
     fig.subplots_adjust(bottom=0.22, right=0.87)
+    # The next several lines ensure that the width of the axes
+    # of all the weekly prediction plots are the same
+    if width is not None:
+        w2, _ = fig.get_size_inches()
+        lm = fig.subplotpars.left * width / w2
+        rm = fig.subplotpars.right * width / w2
+        fig.subplots_adjust(left=lm, right=rm)
 
     return {'fig': fig, 'ax': ax}
 
@@ -146,7 +158,7 @@ def plot_two(fig_id, x, y, x2, y2,
              color='blue', color2='magenta',
              xmin=None, xmax=None, ylim=None, ylim2=None,
              xlabel='', ylabel='', ylabel2='', title='',
-             figsize=(7, 3.5)):
+             figsize=(7, 3.5), load_start=None, width=None):
     """
     Plot two quantities with a date x-axis, one on the left
     y-axis and the other on the right y-axis.
@@ -222,11 +234,23 @@ def plot_two(fig_id, x, y, x2, y2,
     ax2.set_ylabel(ylabel2, color=color2)
     ax2.xaxis.set_visible(False)
 
+    if load_start is not None:
+        # Add a vertical line to mark the start time of the load
+        ax.axvline(load_start, linestyle='-', color='g', linewidth=2.0)
+
     Ska.Matplotlib.set_time_ticks(ax)
     [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
     [label.set_color(color2) for label in ax2.yaxis.get_ticklabels()]
 
     fig.subplots_adjust(bottom=0.22, right=0.87)
+    # The next several lines ensure that the width of the axes
+    # of all the weekly prediction plots are the same
+    if width is not None:
+        w2, _ = fig.get_size_inches()
+        lm = fig.subplotpars.left * width / w2
+        rm = fig.subplotpars.right * width / w2
+        fig.subplots_adjust(left=lm, right=rm)
+
 
     return {'fig': fig, 'ax': ax, 'ax2': ax2}
 

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -331,7 +331,8 @@ def make_state_builder(name, args):
 def get_acis_limits(msid):
     """
     Get the current red and yellow hi limits for a given 
-    ACIS-related MSID. 
+    ACIS-related MSID, or the various limits for the 
+    focal plane temperature.
 
     Parameters
     ----------
@@ -339,6 +340,12 @@ def get_acis_limits(msid):
         The MSID to get the limits for, e.g. "1deamzt".
     """
     import requests
+
+    if msid == "fptemp":
+        fp_sens = -118.7
+        acis_i = -114.0
+        acis_s = -112.0
+        return fp_sens, acis_i, acis_s
 
     yellow_hi = None
     red_hi = None

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -363,15 +363,17 @@ def get_acis_limits(msid):
         cols = (3, 5)
 
     if os.path.exists(file_root):
-        mylog.info("Obtaining limits from local file.")
+        loc = "local"
         f = open(os.path.join(file_root, limits_file), "r")
         lines = f.readlines()
         f.close()
     else:
-        mylog.info("Obtaining limits from remote file.")
+        loc = "remote"
         url = "http://cxc.cfa.harvard.edu/acis/"+limits_file
         u = requests.get(url)
         lines = u.text.split("\n")
+
+    mylog.info("Obtaining limits for %s from %s file." % (msid, loc))
 
     for line in lines:
         words = line.strip().split()

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -343,17 +343,28 @@ def get_acis_limits(msid):
     yellow_hi = None
     red_hi = None
 
+    pmon_file = "PMON/pmon_limits.txt"
+    eng_file = "Thermal/MSID_Limits.txt"
+    file_root = "/proj/web-cxc-dmz/htdocs/acis/"
+
     if msid.startswith("tmp_"):
-        url = "http://cxc.cfa.harvard.edu/acis/PMON/pmon_limits.txt"
+        limits_file = pmon_file
         cols = (5, 6)
         msid = "ADC_"+msid.upper()
     else:
-        url = "http://cxc.cfa.harvard.edu/acis/Thermal/MSID_Limits.txt"
+        limits_file = eng_file
         cols = (3, 5)
 
-    u = requests.get(url)
+    if os.path.exists(file_root):
+        f = open(os.path.join(file_root, limits_file), "r")
+        lines = f.readlines()
+        f.close()
+    else:
+        url = "http://cxc.cfa.harvard.edu/acis/"+limits_file
+        u = requests.get(url)
+        lines = u.text.split("\n")
 
-    for line in u.text.split("\n"):
+    for line in lines:
         words = line.strip().split()
         if len(words) > 1 and words[0] == msid.upper():
             yellow_hi = float(words[cols[0]])

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -343,15 +343,20 @@ def get_acis_limits(msid):
     yellow_hi = None
     red_hi = None
 
-    url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+    if msid.startswith("tmp_"):
+        url = "http://cxc.cfa.harvard.edu/acis/PMON/pmon_limits.txt"
+        cols = (5, 6)
+    else:
+        url = "http://hea-www.cfa.harvard.edu/~acisweb/htdocs/acis/RT-ACIS60-V/limits.txt"
+        cols = (3, 5)
 
     u = requests.get(url)
 
     for line in u.text.split("\n"):
         words = line.strip().split("\t")
         if len(words) > 1 and words[0] == msid.upper():
-            yellow_hi = float(words[3])
-            red_hi = float(words[5])
+            yellow_hi = float(words[cols[0]])
+            red_hi = float(words[cols[1]])
             break
 
     return yellow_hi, red_hi


### PR DESCRIPTION
This PR greatly simplifies and streamlines the `acis_thermal_check` code to reduce code duplication and unnecessary constructs. Since it involves API changes, it will require updates to all of the other thermal model scripts. Other PRs to follow, which will refer back to this one.

Some highlights:

1. Command-line arguments are now passed to `__init__` instead of `driver` (which has been renamed `run`).
2. The construction of the `StateBuilder` object is handled internally.
3. The special handling for the state of the detector housing heater has been moved into `acis_thermal_check` proper so that it is no longer necessary for the PSMC model to subclass `ACISThermalCheck` and overload the `calc_model_wrapper` method.
4. As much of the duplicate code between `acis_thermal_check` and `acisfp_check` as appears feasible has been removed.
5. All fetching of planning and yellow limits has been moved into the `get_acis_limits` function (individual scripts no longer keep their own limits), which fetches these limits from a single official location which is kept up to date. The logic is to try to get the information from the web first and failing that to obtain it from the HEAD LAN.
6. The regression testing suite has been updated to work with the latest changes and to include testing of a large number of loads. 
7. Various simplifications have been made throughout the code where possible.

This PR also adds lines for the planning and yellow limits to the validation plots (except in the focal plane model where the lines for ACIS-I and ACIS-S observations are added).