### PR TITLE
[BUGFIX] Fix bug in get_acis_limits

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -341,7 +341,7 @@ class RegressionTester(object):
         """
         images = ["pow_sim.png", "roll.png"]
         if self.msid == "fptemp":
-            images += ["fptempM120toM112.png",
+            images += ["fptempM120toM111.png",
                        "fptempM120toM119.png",
                        "fptempM120toM90.png"]
         else:

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -373,12 +373,14 @@ def get_acis_limits(msid):
 
     yellow_hi = None
 
-    margin = {"1dpamzt": 2.0, 
-              "1deamzt": 2.0,
-              "1pdeaat": 4.5,
-              "tmp_fep1_mong": 2.0,
-              "tmp_fep1_actel": 2.0,
-              "tmp_bep_pcb": 2.0}
+    margins = {"1dpamzt": 2.0, 
+               "1deamzt": 2.0,
+               "1pdeaat": 4.5,
+               "tmp_fep1_mong": 2.0,
+               "tmp_fep1_actel": 2.0,
+               "tmp_bep_pcb": 2.0}
+
+    margin = margins[msid]
 
     pmon_file = "PMON/pmon_limits.txt"
     eng_file = "Thermal/MSID_Limits.txt"
@@ -411,4 +413,4 @@ def get_acis_limits(msid):
             yellow_hi = float(words[cols[0]])
             break
 
-    return yellow_hi, margin[msid]
+    return yellow_hi, margin


### PR DESCRIPTION
A bug in the `get_acis_limits` function that wasn't caught before the release of version 2.3.0 prevents the yellow and planning limits to be obtained for the models for the DEA board temperatures (with the exception of the focal plane temperature). This PR fixes the bug. The obtaining of limits for the other models were not affected by this bug, and I have tested that all of the limits are now obtained appropriately.

I also fixed a typo in our regression testing framework which does not affect load review runs.

@jeanconn @taldcroft do we need LRB approval for this small change? 