### PR TITLE
[bugfix] Allow the new ACISStateBuilder to work with sqlite and Python 3

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 from acis_thermal_check.main import \
     ACISThermalCheck

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -367,7 +367,8 @@ def make_state_builder(name, args):
         # modules
         state_builder = builder_class(interrupt=args.interrupt,
                                       backstop_file=args.backstop_file,
-                                      nlet_file = args.nlet_file,
+                                      nlet_file=args.nlet_file,
+                                      cmd_states_db=args.cmd_states_db,
                                       logger=mylog)
 
     return state_builder


### PR DESCRIPTION
As previously discussed, we are trying to move away from Sybase to access the commanded states database in favor of sqlite, and we need sqlite to run this on Python 3.

Something that was missed in the last update was that the `ACISStateBuilder` needs to know what we are using to access the commanded states database (sqlite or synapse), which is still used for validation. This PR make sure that this information gets passed to `ACISStateBuilder`.