### PR TITLE
Store xija model objects as attributes, use AstroPy to write tables

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck, \

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -444,7 +444,7 @@ class ACISThermalCheck(object):
 
     def write_temps(self, outdir, times, temps):
         """
-        Write the states record array to the file "states.dat".
+        Write the states record array to the file "temperatures.dat".
 
         Parameters
         ----------

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -436,12 +436,11 @@ class ACISThermalCheck(object):
         outfile = os.path.join(outdir, 'states.dat')
         mylog.info('Writing states to %s' % outfile)
         out = open(outfile, 'w')
-        fmt = {'power': '%.1f',
-               'pitch': '%.2f',
-               'tstart': '%.2f',
-               'tstop': '%.2f'}
-        Ska.Numpy.pprint(states, fmt, out)
-        out.close()
+        states_table = Table(states, copy=False)
+        states_table['pitch'].format = '.2f'
+        states_table['tstart'].format = '.2f'
+        states_table['tstop'].format = '.2f'
+        states_table.write(outfile, format='ascii', delimiter='\t', overwrite=True)
 
     def write_temps(self, outdir, times, temps):
         """

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -437,10 +437,10 @@ class ACISThermalCheck(object):
         mylog.info('Writing states to %s' % outfile)
         out = open(outfile, 'w')
         states_table = Table(states, copy=False)
-        states_table['pitch'].format = '.2f'
-        states_table['tstart'].format = '.2f'
-        states_table['tstop'].format = '.2f'
-        states_table.write(outfile, format='ascii', delimiter='\t', overwrite=True)
+        states_table['pitch'].format = '%.2f'
+        states_table['tstart'].format = '%.2f'
+        states_table['tstop'].format = '%.2f'
+        states_table.write(outfile, format='ascii', delimiter='\t')
 
     def write_temps(self, outdir, times, temps):
         """
@@ -461,9 +461,9 @@ class ACISThermalCheck(object):
         temp_table = Table([times, secs2date(times), T],
                            names=['time', 'date', self.msid],
                            copy=False)
-        temp_table['time'].format = '.2f'
-        temp_table[self.msid].format = '.2f'
-        temp_table.write(outfile, format='ascii', delimiter='\t', overwrite=True)
+        temp_table['time'].format = '%.2f'
+        temp_table[self.msid].format = '%.2f'
+        temp_table.write(outfile, format='ascii', delimiter='\t')
 
     def _make_state_plots(self, plots, num_figs, w1, plot_start,
                           outdir, states, load_start, figsize=(8.5, 4.0)):

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -257,6 +257,8 @@ class ACISThermalCheck(object):
         model = self.calc_model_wrapper(model_spec, states, state0['tstart'],
                                         tstop, state0=state0)
 
+        self.predict_model = model
+
         # Make the limit check plots and data files
         plt.rc("axes", labelsize=10, titlesize=12)
         plt.rc("xtick", labelsize=10)
@@ -626,6 +628,8 @@ class ACISThermalCheck(object):
         # Run the thermal model from the beginning of obtained telemetry
         # to the end, so we can compare its outputs to the real values
         model = self.calc_model_wrapper(model_spec, states, start, stop)
+
+        self.validate_model = model
 
         # Use an OrderedDict here because we want the plots on the validation
         # page to appear in this order


### PR DESCRIPTION
`acis_thermal_check` creates a `xija` model object twice: once for prediction and another time for validation. This PR stores these model objects as attributes of the `ACISThermalCheck` object in case other methods may need to use them for obtaining their data, and fixes an incorrect docstring.

For further information, I'm doing this so that `acisfp_check` can obtain the effective earth solid angle data that the xija model computes.

UPDATE: This PR now implements `astropy.table` to write the `states.dat` and `temperatures.dat` tables.