### PR TITLE
Make commanded states database access default to sqlite, minor plot fixes for Python 3

### DIFF
--- a/acis_thermal_check/__init__.py
+++ b/acis_thermal_check/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 from acis_thermal_check.main import \
     ACISThermalCheck, \

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -675,6 +675,7 @@ class ACISThermalCheck(object):
         quant_table = ''
         quant_head = ",".join(['MSID'] + ["quant%d" % x for x in quantiles])
         quant_table += quant_head + "\n"
+        xmin, xmax = cxctime2plotdate(model.times)[[0, -1]]
         for fig_id, msid in enumerate(pred.keys()):
             plot = dict(msid=msid.upper())
             fig = plt.figure(10 + fig_id, figsize=(7, 3.5))
@@ -715,6 +716,7 @@ class ACISThermalCheck(object):
                         ax.axhline(self.plan_limit_lo, linestyle='--', color='y')
                         ymin = min(self.yellow_lo-1, ymin)
                 ax.set_ylim(ymin, ymax)
+            ax.set_xlim(xmin, xmax)
             filename = msid + '_valid.png'
             outfile = os.path.join(outdir, filename)
             mylog.info('Writing plot file %s' % outfile)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -749,7 +749,7 @@ class ACISThermalCheck(object):
                 fig.clf()
                 ax = fig.gca()
                 ax.hist(diff / scale, bins=50, log=(histscale == 'log'),
-                        histtype='step')
+                        histtype='step', color='b')
                 if ok2.any():
                     ax.hist(diff2 / scale, bins=50, log=(histscale == 'log'),
                             color='red', histtype='step')

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -62,14 +62,13 @@ class TestArgs(object):
         "acis", default "acis".
     cmd_states_db : string, optional
         The mode of database access for the commanded states database.
-        "sybase" or "sqlite". Default: "sybase", unless running in
-        Python 3.
+        "sqlite" or "sybase".
     verbose : integer, optional
         The verbosity of the output. Default: 0
     """
     def __init__(self, name, outdir, model_path, run_start=None,
                  load_week=None, days=21.0, T_init=None, interrupt=False,
-                 state_builder='acis', cmd_states_db=None, verbose=0):
+                 state_builder='acis', cmd_states_db="sqlite", verbose=0):
         from datetime import datetime
         if cmd_states_db is None:
             if six.PY2:

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -62,7 +62,7 @@ class TestArgs(object):
         "acis", default "acis".
     cmd_states_db : string, optional
         The mode of database access for the commanded states database.
-        "sqlite" or "sybase".
+        "sqlite" or "sybase". Default: "sqlite"
     verbose : integer, optional
         The verbosity of the output. Default: 0
     """

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -300,9 +300,9 @@ def get_options(name, model_path, opts=None):
     parser.add_argument("--T-init", type=float,
                         help="Starting temperature (degC or degF, depending on the model). "
                              "Default is to compute it from telemetry.")
-    parser.add_argument("--cmd-states-db", default="sybase",
+    parser.add_argument("--cmd-states-db", default="sqlite",
                         help="Commanded states database server (sybase|sqlite). "
-                             "Only used if state-builder=sql. Default: sybase")
+                             "Default: sqlite")
     parser.add_argument("--state-builder", default="acis",
                         help="StateBuilder to use (sql|acis). Default: acis")
     parser.add_argument("--version", action='store_true', help="Print version")


### PR DESCRIPTION
This PR is designed to allow a full transition to Python 3 / ska3 for ACIS thermal modeling for load review. It does the following:

1. Sets the default access mode for the commanded states database to sqlite instead of sybase, which should be only used going forward and works fully with Python 3.

2. Ensures that the first histogram plot is always plotted in blue (regardless of the Matplotlib version). This maintains previous behavior.

3. Forces the left and right edges of the validation plots to be the beginning and end of data. This maintains previous behavior.

I ran this against the acis_thermal_check regression testing suite for both ska2 and ska3 and all tests passed.