### PR TITLE
[WIP] Refactor acis_thermal_check tests

### DIFF
--- a/acis_thermal_check/conftest.py
+++ b/acis_thermal_check/conftest.py
@@ -5,7 +5,14 @@ def pytest_addoption(parser):
                      help="Generate new answers, but don't test. "
                           "Argument is the directory to store the answers to. "
                           "Default: None, which performs the test.")
+    parser.addoption("--model_spec",
+                     help="The path to the model specification used by "
+                          "the model test run.")
 
 @pytest.fixture()
 def answer_store(request):
     return request.config.getoption('--answer_store')
+
+@pytest.fixture()
+def model_spec(request):
+    return request.config.getoption('--model_spec')

--- a/acis_thermal_check/conftest.py
+++ b/acis_thermal_check/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--answer_store",
+                     help="Generate new answers, but don't test. "
+                          "Argument is the directory to store the answers to. "
+                          "Default: None, which performs the test.")
+
+@pytest.fixture()
+def answer_store(request):
+    return request.config.getoption('--answer_store')

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -780,7 +780,7 @@ class ACISThermalCheck(object):
             filename = os.path.join(outdir, 'validation_data.pkl')
             mylog.info('Writing validation data %s' % filename)
             f = open(filename, 'wb')
-            pickle.dump({'pred': pred, 'tlm': tlm}, f)
+            pickle.dump({'pred': pred, 'tlm': tlm}, f, protocol=2)
             f.close()
 
         return plots

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -324,19 +324,44 @@ class RegressionTester(object):
             tofile = os.path.join(answer_dir, filename)
             shutil.copyfile(fromfile, tofile)
 
-    def check_violation_reporting(self, load_week, model_spec, datestart,
-                                  datestop):
+    def check_violation_reporting(self, load_week, model_spec,
+                                  datestarts, datestops, temps):
+        """
+        This method runs loads which report violations of
+        limits and ensures that they report the violation,
+        as well as the correct start and stop times.
+
+        Parameters
+        ----------
+        load_week : string
+            The load to check. 
+        model_spec : string
+            The path to the model specification file to
+            use. To ensure the violation is reported in
+            the same way, we must use the same model
+            specification file that was used at the time
+            of the run.
+        datestarts : list of strings
+            The start times of the violations.
+        datestops : list of strings
+            The stop times of the violations.
+        temps : list of strings
+            The temperatures which were reached during the
+            violations, in string format rounded to two
+            decimal places.
+        """
+        load_year = "20%s" % load_week[-2:]
         self.run_model(load_week, model_spec)
         out_dir = os.path.join(self.outdir, load_week)
-        msg = "WARNING: {} violates planning limit".format(self.msid.lower())
-        with open(os.path.join(out_dir, "run.dat"), 'r') as myfile:
-            found_warning = False
+        with open(os.path.join(out_dir, "index.rst"), 'r') as myfile:
             lines = myfile.readlines()
+            i = 0
             for line in lines:
-                if msg in line:
-                    found_warning = True
-                    break
-            assert found_warning
-            assert datestart in line
-            assert datestop in line
+                if line.startswith("Model status"):
+                    assert "NOT OK" in line
+                if line.startswith(load_year):
+                    assert datestarts[i] in line
+                    assert datestops[i] in line
+                    assert temps[i] in line
+                    i += 1
 

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -94,6 +94,7 @@ class TestArgs(object):
         if name == "acisfp":
             self.fps_nopref = os.path.join(model_path, "FPS_NoPref.txt")
 
+
 # Large, multi-layer dictionary which encodes the datatypes for the
 # different quantities that are being checked against.
 data_dtype = {'temperatures': {'names': ('time', 'date', 'temperature'),
@@ -115,6 +116,7 @@ data_dtype = {'temperatures': {'names': ('time', 'date', 'temperature'),
                         }
              }
 
+
 def exception_catcher(test, old, new, data_type, **kwargs):
     if new.dtype.kind == "S":
         new = new.astype("U")
@@ -124,6 +126,7 @@ def exception_catcher(test, old, new, data_type, **kwargs):
         test(old, new, **kwargs)
     except AssertionError:
         raise AssertionError("%s are not the same!" % data_type)
+
 
 class RegressionTester(object):
     def __init__(self, msid, name, model_path, valid_limits,
@@ -148,7 +151,7 @@ class RegressionTester(object):
             os.mkdir(self.outdir)
 
     def run_model(self, load_week, run_start=None, state_builder='acis',
-                  interrupt=False, cmd_states_db="sybase"):
+                  interrupt=False, cmd_states_db="sqlite"):
         out_dir = os.path.join(self.outdir, load_week)
         args = TestArgs(self.name, out_dir, self.model_path, run_start=run_start,
                         load_week=load_week, interrupt=interrupt,

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -49,7 +49,7 @@ class TestArgs(object):
         determined from telemetry.
     interrupt : boolean, optional
         Whether or not this is an interrupt load. Default: False
-    state_builder string, optional
+    state_builder : string, optional
         The mode used to create the list of commanded states. "sql" or
         "acis", default "acis".
     cmd_states_db : string, optional
@@ -57,6 +57,9 @@ class TestArgs(object):
         "sqlite" or "sybase". Default: "sqlite"
     verbose : integer, optional
         The verbosity of the output. Default: 0
+    model_spec : string, optional
+        The path to the model specification file to use. Default is to
+        use the model specification file stored in the model package.
     """
     def __init__(self, name, outdir, model_path, run_start=None,
                  load_week=None, days=21.0, T_init=None, interrupt=False,
@@ -155,7 +158,33 @@ class RegressionTester(object):
             os.mkdir(self.outdir)
 
     def run_model(self, load_week, run_start=None, state_builder='acis',
-                  interrupt=False, cmd_states_db="sqlite", model_spec=None):
+                  interrupt=False, cmd_states_db="sqlite", model_spec=None,
+                  override_limits=None):
+        """
+        Run a thermal model in test mode for a single load week.
+
+        Parameters
+        ----------
+        load_week : string
+            The load week to be tested, in a format like "MAY2016A".
+        run_start : string, optional
+            The run start time in YYYY:DOY:HH:MM:SS.SSS format. If not
+            specified, one will be created 3 days prior to the model run.
+        state_builder : string, optional
+            The mode used to create the list of commanded states. "sql" or
+            "acis", default "acis".
+        interrupt : boolean, optional
+            Whether or not this is an interrupt load. Default: False
+        cmd_states_db : string, optional
+            The mode of database access for the commanded states database.
+            "sqlite" or "sybase". Default: "sqlite"
+        model_spec : string, optional
+            The path to the model specification file to use. Default is to
+        use the model specification file stored in the model package.
+            override_limits : dict, optional
+            Override any margin by setting a new value to its name
+            in this dictionary. SHOULD ONLY BE USED FOR TESTING.
+        """
         out_dir = os.path.join(self.outdir, load_week)
         args = TestArgs(self.name, out_dir, self.model_path, run_start=run_start,
                         load_week=load_week, interrupt=interrupt,
@@ -164,10 +193,29 @@ class RegressionTester(object):
         msid_check = self.atc_class(self.msid, self.name, self.valid_limits,
                                     self.hist_limit, self.calc_model, args,
                                     **self.atc_kwargs)
-        msid_check.run()
+        msid_check.run(override_limits=override_limits)
 
     def run_models(self, normal=True, interrupt=True, run_start=None,
                    state_builder='acis', cmd_states_db='sqlite'):
+        """
+        Run the internally set list of models for regression testing.
+
+        Parameters
+        ----------
+        normal : boolean, optional
+            Run the "normal" loads. Default: True
+        interrupt : boolean, optional
+            Run the "interrupt" loads. Default: True
+        run_start : string, optional
+            The run start time in YYYY:DOY:HH:MM:SS.SSS format. If not
+            specified, one will be created 3 days prior to the model run.
+        state_builder : string, optional
+            The mode used to create the list of commanded states. "sql" or
+            "acis", default "acis".
+        cmd_states_db : string, optional
+            The mode of database access for the commanded states database.
+            "sqlite" or "sybase". Default: "sqlite"
+        """
         if normal:
             for load in test_loads["normal"]:
                 self.run_model(load, run_start=run_start,
@@ -325,7 +373,8 @@ class RegressionTester(object):
             shutil.copyfile(fromfile, tofile)
 
     def check_violation_reporting(self, load_week, model_spec,
-                                  datestarts, datestops, temps):
+                                  run_start, datestarts, datestops, 
+                                  temps, override_limits=None):
         """
         This method runs loads which report violations of
         limits and ensures that they report the violation,
@@ -337,10 +386,12 @@ class RegressionTester(object):
             The load to check. 
         model_spec : string
             The path to the model specification file to
-            use. To ensure the violation is reported in
-            the same way, we must use the same model
-            specification file that was used at the time
-            of the run.
+            use. For this test, to ensure the violation is
+            reported in the same way, we must use the same
+            model specification file that was used at the
+            time of the run.
+        run_start : string
+            The run start time in YYYY:DOY:HH:MM:SS.SSS format.
         datestarts : list of strings
             The start times of the violations.
         datestops : list of strings
@@ -349,14 +400,19 @@ class RegressionTester(object):
             The temperatures which were reached during the
             violations, in string format rounded to two
             decimal places.
+        override_limits : dict, optional
+            Override any margin by setting a new value to its name
+            in this dictionary. SHOULD ONLY BE USED FOR TESTING.
         """
-        load_year = "20%s" % load_week[-2:]
-        self.run_model(load_week, model_spec)
+        load_year = "20%s" % load_week[-3:-1]
+        self.run_model(load_week, run_start=run_start, 
+                       model_spec=model_spec,
+                       override_limits=override_limits)
         out_dir = os.path.join(self.outdir, load_week)
+        os.system("cp %s /Users/jzuhone" % os.path.join(out_dir, "index.rst"))
         with open(os.path.join(out_dir, "index.rst"), 'r') as myfile:
-            lines = myfile.readlines()
             i = 0
-            for line in lines:
+            for line in myfile.readlines():
                 if line.startswith("Model status"):
                     assert "NOT OK" in line
                 if line.startswith(load_year):

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -162,27 +162,22 @@ class RegressionTester(object):
                 os.makedirs(answer_dir)
         return answer_dir
 
-    def run_test(self, test_name, answer_dir, load_week, image=None):
+    def run_test(self, test_name, answer_dir, load_week):
         """
-        This function runs the image answer test in one of two modes:
-        either comparing the image answers from this test to the "gold
-        standard" answers or to simply run the model to generate image
-        answers.
+        This function runs the answer test in one of two modes:
+        either comparing the answers from this test to the "gold
+        standard" answers or to simply run the model to generate answers.
 
         Parameters
         ----------
         test_name : string
-            The name of the test to run. "prediction", "validation", or 
-            "image".
+            The name of the test to run. "prediction" or "validation".
         answer_dir : string
             The path to the directory to which to copy the files. Is None
             if this is a test run, is an actual directory if we are simply
             generating answers.
         load_week : string
             The load week to be tested, in a format like "MAY2016A".
-        image : string, optional
-            The filename of the image to be compared, if running the image
-            test.
         """
         answer_dir = self._set_answer_dir(answer_dir, load_week)
         out_dir = os.path.join(self.outdir, load_week)
@@ -192,7 +187,7 @@ class RegressionTester(object):
             filenames = ["validation_data.pkl"]
         else:
             raise RuntimeError("Invalid test specification! "
-                               "Test name = %s, image = %s." % (test_name, image))
+                               "Test name = %s." % test_name)
         if not answer_dir:
             compare_test = getattr(self, "compare_"+test_name)
             compare_test(load_week, out_dir)

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -189,7 +189,7 @@ class RegressionTester(object):
 
     def run_test(self, test_name, answer_dir, load_week):
         """
-        This function runs the answer test in one of two modes:
+        This method runs the answer test in one of two modes:
         either comparing the answers from this test to the "gold
         standard" answers or to simply run the model to generate answers.
 
@@ -223,7 +223,7 @@ class RegressionTester(object):
 
     def compare_validation(self, load_week, out_dir, filenames):
         """
-        This function compares the "gold standard" validation data 
+        This method compares the "gold standard" validation data 
         with the current test run's data.
 
         Parameters
@@ -273,7 +273,7 @@ class RegressionTester(object):
 
     def compare_prediction(self, load_week, out_dir, filenames):
         """
-        This function compares the "gold standard" prediction data with 
+        This method compares the "gold standard" prediction data with 
         the current test run's data for the .dat files produced in the 
         thermal model run.
 
@@ -305,7 +305,7 @@ class RegressionTester(object):
  
     def copy_new_files(self, out_dir, answer_dir, filenames):
         """
-        This function copies the files generated in this test
+        This method copies the files generated in this test
         run to a directory specified by the user, typically for
         inspection and for possible updating of the "gold standard"
         answers.

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -6,17 +6,7 @@ import shutil
 import numpy as np
 import tempfile
 from .main import ACISThermalCheck
-import pytest
 import six
-
-def pytest_addoption(parser):
-    parser.addoption("--answer_store",
-                     help="Generate new answers, but don't test. "
-                          "Argument is the directory to store the answers to.")
-
-@pytest.fixture()
-def answer_store(request):
-    return request.config.getoption('--answer_store')
 
 months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
           "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"]

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -17,8 +17,9 @@ test_data_dir = "/data/acis/thermal_model_tests"
 
 # Loads for regression testing
 test_loads = {"normal": ["MAR0617A", "MAR2017E", "JUL3117B", "SEP0417A"],
-              "too": ["MAR1517B", "JUL2717A", "AUG2517C", "AUG3017A"],
-              "stop": ["MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"]}
+              "interrupt": ["MAR1517B", "JUL2717A", "AUG2517C", "AUG3017A",
+                            "MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"]}
+all_loads = test_loads["normal"]+test_loads["interrupt"]
 
 class TestArgs(object):
     """

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -207,7 +207,7 @@ class RegressionTester(object):
                                "Test name = %s." % test_name)
         if not answer_dir:
             compare_test = getattr(self, "compare_"+test_name)
-            compare_test(load_week, out_dir)
+            compare_test(load_week, out_dir, filenames)
         else:
             self.copy_new_files(out_dir, answer_dir, filenames)
 

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -21,6 +21,7 @@ test_loads = {"normal": ["MAR0617A", "MAR2017E", "JUL3117B", "SEP0417A"],
                             "MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"]}
 all_loads = test_loads["normal"]+test_loads["interrupt"]
 
+
 class TestArgs(object):
     """
     A mock-up of a command-line parser object to be used with
@@ -161,13 +162,18 @@ class RegressionTester(object):
                                     **self.atc_kwargs)
         msid_check.run()
 
-    def run_models(self, normal=True, interrupt=True):
+    def run_models(self, normal=True, interrupt=True, run_start=None,
+                   state_builder='acis', cmd_states_db='sqlite'):
         if normal:
             for load in test_loads["normal"]:
-                self.run_model(load)
+                self.run_model(load, run_start=run_start,
+                               state_builder=state_builder,
+                               cmd_states_db=cmd_states_db)
         if interrupt:
             for load in test_loads["interrupt"]:
-                self.run_model(load, interrupt=True)
+                self.run_model(load, interrupt=True, run_start=run_start,
+                               state_builder=state_builder,
+                               cmd_states_db=cmd_states_db)
 
     def _set_answer_dir(self, answer_dir, load_week):
         if answer_dir is not None:

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -203,7 +203,7 @@ class RegressionTester(object):
         else:
             self.copy_new_files(out_dir, answer_dir, filenames)
 
-    def compare_validation(self, load_week, out_dir):
+    def compare_validation(self, load_week, out_dir, filenames):
         """
         This function compares the "gold standard" validation data 
         with the current test run's data.
@@ -214,13 +214,16 @@ class RegressionTester(object):
             The load week to be tested, in a format like "MAY2016A".
         out_dir : string
             The path to the output directory.
+        filenames : list of strings
+            The list of files which will be used in the comparison.
+            Currently only "validation_data.pkl".
         """
         # First load the answers from the pickle files, both gold standard
         # and current
-        new_answer_file = os.path.join(out_dir, "validation_data.pkl")
+        new_answer_file = os.path.join(out_dir, filenames[0])
         new_results = pickle.load(open(new_answer_file, "rb"))
         old_answer_file = os.path.join(test_data_dir, self.name, load_week,
-                                       "validation_data.pkl")
+                                       filenames[0])
         kwargs = {} if six.PY2 else {'encoding': 'latin1'}
         old_results = pickle.load(open(old_answer_file, "rb"), **kwargs)
         # Compare predictions
@@ -250,21 +253,23 @@ class RegressionTester(object):
             exception_catcher(assert_array_equal, new_tlm[k], old_tlm[k],
                               "Validation telemetry arrays for %s" % k)
 
-    def compare_prediction(self, load_week, out_dir):
+    def compare_prediction(self, load_week, out_dir, filenames):
         """
         This function compares the "gold standard" prediction data with 
         the current test run's data for the .dat files produced in the 
         thermal model run.
-      
+
         Parameters
         ----------
-        load_week : string                                                                                                                                                                                           
-            The load week to be tested, in a format like "MAY2016A".                                                                                                                                                
+        load_week : string
+            The load week to be tested, in a format like "MAY2016A".
         out_dir : string
             The path to the output directory.
+        filenames : list of strings
+            The list of files which will be used in the comparison.
         """
-        for prefix in ("temperatures", "states"):
-            fn = prefix+".dat"
+        for fn in filenames:
+            prefix = fn.split(".")[0]
             new_fn = os.path.join(out_dir, fn)
             old_fn = os.path.join(test_data_dir, self.name, load_week, fn)
             new_data = np.loadtxt(new_fn, skiprows=1, dtype=data_dtype[prefix])

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -99,6 +99,9 @@ class TestArgs(object):
 data_dtype = {'temperatures': {'names': ('time', 'date', 'temperature'),
                                'formats': ('f8', 'S21', 'f8')
                               },
+              'earth_solid_angles': {'names': ('time', 'date', 'earth_solid_angle'),
+                                     'formats': ('f8', 'S21', 'f8')
+                                     },
               'states': {'names': ('ccd_count', 'clocking', 'datestart',
                                    'datestop', 'dec', 'dither', 'fep_count',
                                    'hetg', 'letg', 'obsid', 'pcad_mode',
@@ -192,6 +195,8 @@ class RegressionTester(object):
         out_dir = os.path.join(self.outdir, load_week)
         if test_name == "prediction":
             filenames = ["temperatures.dat", "states.dat"]
+            if self.name == "acisfp":
+                filenames.append("earth_solid_angles.dat")
         elif test_name == "validation":
             filenames = ["validation_data.pkl"]
         else:

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -374,7 +374,7 @@ class RegressionTester(object):
 
     def check_violation_reporting(self, load_week, model_spec,
                                   run_start, datestarts, datestops, 
-                                  temps, override_limits=None):
+                                  temps, obsids=None, override_limits=None):
         """
         This method runs loads which report violations of
         limits and ensures that they report the violation,
@@ -400,6 +400,9 @@ class RegressionTester(object):
             The temperatures which were reached during the
             violations, in string format rounded to two
             decimal places.
+        obsids : list of strings
+            For the focal plane model, these are the obsids
+            during which the violations occurred.
         override_limits : dict, optional
             Override any margin by setting a new value to its name
             in this dictionary. SHOULD ONLY BE USED FOR TESTING.
@@ -419,5 +422,7 @@ class RegressionTester(object):
                     assert datestarts[i] in line
                     assert datestops[i] in line
                     assert temps[i] in line
+                    if self.msid == "fptemp":
+                        assert obsids[i] in line
                     i += 1
 

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -16,9 +16,9 @@ months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
 test_data_dir = "/data/acis/thermal_model_tests"
 
 # Loads for regression testing
-normal_loads = ["MAR0617A", "MAR2017E", "JUL3117B", "SEP0417A"]
-too_loads = ["MAR1517B", "JUL2717A", "AUG2517C", "AUG3017A"]
-stop_loads = ["MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"]
+test_loads = {"normal": ["MAR0617A", "MAR2017E", "JUL3117B", "SEP0417A"],
+              "too": ["MAR1517B", "JUL2717A", "AUG2517C", "AUG3017A"],
+              "stop": ["MAR0817B", "MAR1117A", "APR0217B", "SEP0917C"]}
 
 class TestArgs(object):
     """
@@ -137,46 +137,22 @@ class RegressionTester(object):
         if atc_class is None:
             atc_class = ACISThermalCheck
         self.atc_class = atc_class
+        self.curdir = os.getcwd()
+        self.tmpdir = tempfile.mkdtemp()
+        self.outdir = os.path.join(self.tmpdir, self.name+"_test")
 
-    def run_test_arrays(self, generate_answers, exclude_images=None, 
-                        state_builder='acis', run_start=None):
-        for load_week in normal_loads:
-            self.load_test_template(load_week, generate_answers, interrupt=False, 
-                                    exclude_images=exclude_images, 
-                                    state_builder=state_builder, run_start=run_start)
-        for load_week in too_loads:
-            self.load_test_template(load_week, generate_answers, interrupt=True, 
-                                    exclude_images=exclude_images, 
-                                    state_builder=state_builder, run_start=run_start)
-        for load_week in stop_loads:
-            self.load_test_template(load_week, generate_answers, interrupt=True, 
-                                    exclude_images=exclude_images, 
-                                    state_builder=state_builder, run_start=run_start)
-
-    def load_test_template(self, load_week, generate_answers, run_start=None,
-                           state_builder='acis', interrupt=False, 
-                           exclude_images=None):
-        if generate_answers is not None:
-            generate_answers = os.path.join(os.path.abspath(generate_answers),
-                                            self.name, load_week)
-            if not os.path.exists(generate_answers):
-                os.makedirs(generate_answers)
-        tmpdir = tempfile.mkdtemp()
-        curdir = os.getcwd()
-        os.chdir(tmpdir)
-        out_dir = self.name+"_test"
-        args = TestArgs(self.name, out_dir, self.model_path, run_start=run_start,
+    def load_test_template(self, load_week, run_start=None, state_builder='acis',
+                           interrupt=False, cmd_states_db="sybase"):
+        args = TestArgs(self.name, self.outdir, self.model_path, run_start=run_start,
                         load_week=load_week, interrupt=interrupt,
-                        state_builder=state_builder)
+                        state_builder=state_builder, cmd_states_db=cmd_states_db)
         msid_check = self.atc_class(self.msid, self.name, self.valid_limits,
                                     self.hist_limit, self.calc_model, args,
                                     **self.atc_kwargs)
         msid_check.run()
-        self.run_answer_test(load_week, out_dir, generate_answers)
-        os.chdir(curdir)
-        shutil.rmtree(tmpdir)
+        #shutil.rmtree(self.tmpdir)
 
-    def run_answer_test(self, load_week, out_dir, answer_dir):
+    def run_answer_test(self, answer_dir, load_week):
         """
         This function runs the answer test in one of two modes:
         either comparing the answers from this test to the "gold
@@ -185,18 +161,21 @@ class RegressionTester(object):
 
         Parameters
         ----------
-        load_week : string, optional
-            The load week to be tested, in a format like "MAY2016". If not
-            provided, it is assumed that a full set of initial states will
-            be supplied.
-        out_dir : string
-            The path to the output directory.
         answer_dir : string
             The path to the directory to which to copy the files. Is None
             if this is a test run, is an actual directory if we are simply
             generating answers.
+        load_week : string, optional
+            The load week to be tested, in a format like "MAY2016". If not
+            provided, it is assumed that a full set of initial states will
+            be supplied.
         """
-        out_dir = os.path.abspath(out_dir)
+        if answer_dir is not None:
+            answer_dir = os.path.join(os.path.abspath(answer_dir),
+                                      self.name, load_week)
+            if not os.path.exists(answer_dir):
+                os.makedirs(answer_dir)
+        out_dir = os.path.abspath(self.outdir)
         if not answer_dir:
             self.compare_results(load_week, out_dir)
         else:

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -155,6 +155,14 @@ class RegressionTester(object):
                                     **self.atc_kwargs)
         msid_check.run()
 
+    def run_models(self, normal=True, interrupt=True):
+        if normal:
+            for load in test_loads["normal"]:
+                self.run_model(load)
+        if interrupt:
+            for load in test_loads["interrupt"]:
+                self.run_model(load, interrupt=True)
+
     def _set_answer_dir(self, answer_dir, load_week):
         if answer_dir is not None:
             answer_dir = os.path.join(os.path.abspath(answer_dir),

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -139,59 +139,75 @@ class RegressionTester(object):
         self.atc_class = atc_class
         self.curdir = os.getcwd()
         self.tmpdir = tempfile.mkdtemp()
-        self.outdir = os.path.join(self.tmpdir, self.name+"_test")
+        self.outdir = os.path.abspath(os.path.join(self.tmpdir, self.name+"_test"))
+        if not os.path.exists(self.outdir):
+            os.mkdir(self.outdir)
 
-    def load_test_template(self, load_week, run_start=None, state_builder='acis',
-                           interrupt=False, cmd_states_db="sybase"):
-        args = TestArgs(self.name, self.outdir, self.model_path, run_start=run_start,
+    def run_model(self, load_week, run_start=None, state_builder='acis',
+                  interrupt=False, cmd_states_db="sybase"):
+        out_dir = os.path.join(self.outdir, load_week)
+        args = TestArgs(self.name, out_dir, self.model_path, run_start=run_start,
                         load_week=load_week, interrupt=interrupt,
                         state_builder=state_builder, cmd_states_db=cmd_states_db)
         msid_check = self.atc_class(self.msid, self.name, self.valid_limits,
                                     self.hist_limit, self.calc_model, args,
                                     **self.atc_kwargs)
         msid_check.run()
-        #shutil.rmtree(self.tmpdir)
 
-    def run_answer_test(self, answer_dir, load_week):
-        """
-        This function runs the answer test in one of two modes:
-        either comparing the answers from this test to the "gold
-        standard" answers or to simply run the model to generate
-        answers.
-
-        Parameters
-        ----------
-        answer_dir : string
-            The path to the directory to which to copy the files. Is None
-            if this is a test run, is an actual directory if we are simply
-            generating answers.
-        load_week : string, optional
-            The load week to be tested, in a format like "MAY2016". If not
-            provided, it is assumed that a full set of initial states will
-            be supplied.
-        """
+    def _set_answer_dir(self, answer_dir, load_week):
         if answer_dir is not None:
             answer_dir = os.path.join(os.path.abspath(answer_dir),
                                       self.name, load_week)
             if not os.path.exists(answer_dir):
                 os.makedirs(answer_dir)
-        out_dir = os.path.abspath(self.outdir)
-        if not answer_dir:
-            self.compare_results(load_week, out_dir)
-        else:
-            self.copy_new_results(out_dir, answer_dir)
+        return answer_dir
 
-    def compare_results(self, load_week, out_dir):
+    def run_test(self, test_name, answer_dir, load_week, image=None):
         """
-        This function compares the "gold standard" data with the current
-        test run's data.
+        This function runs the image answer test in one of two modes:
+        either comparing the image answers from this test to the "gold
+        standard" answers or to simply run the model to generate image
+        answers.
 
         Parameters
         ----------
-        load_week : string, optional
-            The load week to be tested, in a format like "MAY2016". If not
-            provided, it is assumed that a full set of initial states will
-            be supplied.
+        test_name : string
+            The name of the test to run. "prediction", "validation", or 
+            "image".
+        answer_dir : string
+            The path to the directory to which to copy the files. Is None
+            if this is a test run, is an actual directory if we are simply
+            generating answers.
+        load_week : string
+            The load week to be tested, in a format like "MAY2016A".
+        image : string, optional
+            The filename of the image to be compared, if running the image
+            test.
+        """
+        answer_dir = self._set_answer_dir(answer_dir, load_week)
+        out_dir = os.path.join(self.outdir, load_week)
+        if test_name == "prediction":
+            filenames = ["temperatures.dat", "states.dat"]
+        elif test_name == "validation":
+            filenames = ["validation_data.pkl"]
+        else:
+            raise RuntimeError("Invalid test specification! "
+                               "Test name = %s, image = %s." % (test_name, image))
+        if not answer_dir:
+            compare_test = getattr(self, "compare_"+test_name)
+            compare_test(load_week, out_dir)
+        else:
+            self.copy_new_files(out_dir, answer_dir, filenames)
+
+    def compare_validation(self, load_week, out_dir):
+        """
+        This function compares the "gold standard" validation data 
+        with the current test run's data.
+
+        Parameters
+        ----------
+        load_week : string
+            The load week to be tested, in a format like "MAY2016A".
         out_dir : string
             The path to the output directory.
         """
@@ -215,7 +231,7 @@ class RegressionTester(object):
                 print("WARNING in pred: '%s' in new answer but not old. Answers should be updated." % k)
                 continue
             exception_catcher(assert_allclose, new_pred[k], old_pred[k],
-                              "Validation model arrays for %s" % k)
+                              "Validation model arrays for %s" % k, rtol=1.0e-5)
         # Compare telemetry
         new_tlm = new_results['tlm']
         old_tlm = old_results['tlm']
@@ -229,49 +245,43 @@ class RegressionTester(object):
                 continue
             exception_catcher(assert_array_equal, new_tlm[k], old_tlm[k],
                               "Validation telemetry arrays for %s" % k)
-        # Compare
-        for prefix in ("temperatures", "states"):
-            self.compare_data_files(prefix, load_week, out_dir)
 
-    def compare_data_files(self, prefix, load_week, out_dir):
+    def compare_prediction(self, load_week, out_dir):
         """
-        This function compares the "gold standard" data with the current
-        test run's data for the .dat files produced in the thermal model
-        run. Called by ``compare_results``.
-
+        This function compares the "gold standard" prediction data with 
+        the current test run's data for the .dat files produced in the 
+        thermal model run.
+      
         Parameters
         ----------
-        prefix : string
-            The prefix of the file, "temperatures" or "states".
-        load_week : string, optional
-            The load week to be tested, in a format like "MAY2016". If not
-            provided, it is assumed that a full set of initial states will
-            be supplied.
+        load_week : string                                                                                                                                                                                           
+            The load week to be tested, in a format like "MAY2016A".                                                                                                                                                
         out_dir : string
             The path to the output directory.
         """
-        fn = prefix+".dat"
-        new_fn = os.path.join(out_dir, fn)
-        old_fn = os.path.join(test_data_dir, self.name, load_week, fn)
-        new_data = np.loadtxt(new_fn, skiprows=1, dtype=data_dtype[prefix])
-        old_data = np.loadtxt(old_fn, skiprows=1, dtype=data_dtype[prefix])
-        # Compare test run data to gold standard. Since we're loading from
-        # ASCII text files here, floating-point comparisons will be different
-        # at machine precision, others will be exact.
-        for k, dt in new_data.dtype.descr:
-            if 'f' in dt:
-                exception_catcher(assert_allclose, new_data[k], old_data[k],
-                                  "Prediction arrays for %s" % k, rtol=1.0e-5)
-            else:
-                exception_catcher(assert_array_equal, new_data[k], old_data[k],
-                                  "Prediction arrays for %s" % k)
-
-    def copy_new_results(self, out_dir, answer_dir):
+        for prefix in ("temperatures", "states"):
+            fn = prefix+".dat"
+            new_fn = os.path.join(out_dir, fn)
+            old_fn = os.path.join(test_data_dir, self.name, load_week, fn)
+            new_data = np.loadtxt(new_fn, skiprows=1, dtype=data_dtype[prefix])
+            old_data = np.loadtxt(old_fn, skiprows=1, dtype=data_dtype[prefix])
+            # Compare test run data to gold standard. Since we're loading from
+            # ASCII text files here, floating-point comparisons will be different
+            # at machine precision, others will be exact.
+            for k, dt in new_data.dtype.descr:
+                if 'f' in dt:
+                    exception_catcher(assert_allclose, new_data[k], old_data[k],
+                                      "Prediction arrays for %s" % k, rtol=1.0e-5)
+                else:
+                    exception_catcher(assert_array_equal, new_data[k], old_data[k],
+                                      "Prediction arrays for %s" % k)
+ 
+    def copy_new_files(self, out_dir, answer_dir, filenames):
         """
-        This function copies the pickle files and the .dat files
-        generated in this test run to a directory specified by the
-        user, typically for inspection and for possible updating of
-        the "gold standard" answers.
+        This function copies the files generated in this test
+        run to a directory specified by the user, typically for
+        inspection and for possible updating of the "gold standard"
+        answers.
 
         Parameters
         ----------
@@ -279,9 +289,10 @@ class RegressionTester(object):
             The path to the output directory.
         answer_dir : string
             The path to the directory to which to copy the files.
+        filenames : list of strings
+            The filenames to be copied.
         """
-        for fn in ('validation_data.pkl', 'states.dat', 'temperatures.dat'):
-            fromfile = os.path.join(out_dir, fn)
-            tofile = os.path.join(answer_dir, fn)
+        for filename in filenames:
+            fromfile = os.path.join(out_dir, filename)
+            tofile = os.path.join(answer_dir, filename)
             shutil.copyfile(fromfile, tofile)
-

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -60,7 +60,8 @@ class TestArgs(object):
     """
     def __init__(self, name, outdir, model_path, run_start=None,
                  load_week=None, days=21.0, T_init=None, interrupt=False,
-                 state_builder='acis', cmd_states_db="sqlite", verbose=0):
+                 state_builder='acis', cmd_states_db="sqlite", verbose=0,
+                 model_spec=None):
         from datetime import datetime
         if cmd_states_db is None:
             if six.PY2:
@@ -90,7 +91,9 @@ class TestArgs(object):
         self.T_init = T_init
         self.traceback = True
         self.verbose = verbose
-        self.model_spec = os.path.join(model_path, "%s_model_spec.json" % name)
+        if model_spec is None:
+            model_spec = os.path.join(model_path, "%s_model_spec.json" % name)
+        self.model_spec = model_spec
         self.version = None
         if name == "acisfp":
             self.fps_nopref = os.path.join(model_path, "FPS_NoPref.txt")
@@ -152,11 +155,12 @@ class RegressionTester(object):
             os.mkdir(self.outdir)
 
     def run_model(self, load_week, run_start=None, state_builder='acis',
-                  interrupt=False, cmd_states_db="sqlite"):
+                  interrupt=False, cmd_states_db="sqlite", model_spec=None):
         out_dir = os.path.join(self.outdir, load_week)
         args = TestArgs(self.name, out_dir, self.model_path, run_start=run_start,
                         load_week=load_week, interrupt=interrupt,
-                        state_builder=state_builder, cmd_states_db=cmd_states_db)
+                        state_builder=state_builder, cmd_states_db=cmd_states_db,
+                        model_spec=model_spec)
         msid_check = self.atc_class(self.msid, self.name, self.valid_limits,
                                     self.hist_limit, self.calc_model, args,
                                     **self.atc_kwargs)
@@ -319,3 +323,20 @@ class RegressionTester(object):
             fromfile = os.path.join(out_dir, filename)
             tofile = os.path.join(answer_dir, filename)
             shutil.copyfile(fromfile, tofile)
+
+    def check_violation_reporting(self, load_week, model_spec, datestart,
+                                  datestop):
+        self.run_model(load_week, model_spec)
+        out_dir = os.path.join(self.outdir, load_week)
+        msg = "WARNING: {} violates planning limit".format(self.msid.lower())
+        with open(os.path.join(out_dir, "run.dat"), 'r') as myfile:
+            found_warning = False
+            lines = myfile.readlines()
+            for line in lines:
+                if msg in line:
+                    found_warning = True
+                    break
+            assert found_warning
+            assert datestart in line
+            assert datestop in line
+

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -28,20 +28,6 @@ class StateBuilder(object):
         """
         raise NotImplementedError("'StateBuilder should be subclassed!")
 
-    def get_validation_states(self, datestart, datestop):
-        """
-        Get states for validation of the thermal model.
-
-        Parameters
-        ----------
-        datestart : string
-            The start date to grab states afterward.
-        datestop : string
-            The end date to grab states before.
-        """
-        raise NotImplementedError("'StateBuilder should be subclassed!")
-
-
     def _get_bs_cmds(self):
         """
         Internal method used to obtain commands from the backstop 
@@ -62,6 +48,41 @@ class StateBuilder(object):
         self.tstart = bs_cmds[0]['time']
         self.tstop = bs_cmds[-1]['time']
 
+    def get_validation_states(self, datestart, datestop):
+        """
+        Get states for validation of the thermal model.
+
+        Parameters
+        ----------
+        datestart : string
+            The start date to grab states afterward.
+        datestop : string
+            The end date to grab states before.
+        """
+        datestart = DateTime(datestart).date
+        datestop = DateTime(datestop).date
+        self.logger.info('Getting commanded states between %s - %s' %
+                         (datestart, datestop))
+
+        # Get all states that intersect specified date range
+        cmd = """SELECT * FROM cmd_states
+                 WHERE datestop > '%s' AND datestart < '%s'
+                 ORDER BY datestart""" % (datestart, datestop)
+        self.logger.debug('Query command: %s' % cmd)
+        states = self.db.fetchall(cmd)
+        self.logger.info('Found %d commanded states' % len(states))
+
+        # Set start and end state date/times to match telemetry span.  Extend the
+        # state durations by a small amount because of a precision issue converting
+        # to date and back to secs.  (The reference tstop could be just over the
+        # 0.001 precision of date and thus cause an out-of-bounds error when
+        # interpolating state values).
+        states[0].tstart = DateTime(datestart).secs - 0.01
+        states[0].datestart = DateTime(states[0].tstart).date
+        states[-1].tstop = DateTime(datestop).secs + 0.01
+        states[-1].datestop = DateTime(states[-1].tstop).date
+
+        return states
 
 
 class SQLStateBuilder(StateBuilder):
@@ -186,41 +207,6 @@ class SQLStateBuilder(StateBuilder):
 
         return states, state0
 
-    def get_validation_states(self, datestart, datestop):
-        """
-        Get states for validation of the thermal model.
-
-        Parameters
-        ----------
-        datestart : string
-            The start date to grab states afterward.
-        datestop : string
-            The end date to grab states before.
-        """
-        datestart = DateTime(datestart).date
-        datestop = DateTime(datestop).date
-        self.logger.info('Getting commanded states between %s - %s' %
-                         (datestart, datestop))
-
-        # Get all states that intersect specified date range
-        cmd = """SELECT * FROM cmd_states
-                 WHERE datestop > '%s' AND datestart < '%s'
-                 ORDER BY datestart""" % (datestart, datestop)
-        self.logger.debug('Query command: %s' % cmd)
-        states = self.db.fetchall(cmd)
-        self.logger.info('Found %d commanded states' % len(states))
-
-        # Set start and end state date/times to match telemetry span.  Extend the
-        # state durations by a small amount because of a precision issue converting
-        # to date and back to secs.  (The reference tstop could be just over the
-        # 0.001 precision of date and thus cause an out-of-bounds error when
-        # interpolating state values).
-        states[0].tstart = DateTime(datestart).secs - 0.01
-        states[0].datestart = DateTime(states[0].tstart).date
-        states[-1].tstop = DateTime(datestop).secs + 0.01
-        states[-1].datestop = DateTime(states[-1].tstop).date
-
-        return states
 
 #-------------------------------------------------------------------------------
 # ACIS Ops Load History assembly 
@@ -287,7 +273,7 @@ class ACISStateBuilder(StateBuilder):
                   os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3'))
         self.logger.info('Connecting to {} to get cmd_states'.format(server))
         self.db = Ska.DBI.DBI(dbi=cmd_states_db, server=server, user='aca_read',
-                              database='aca')   
+                              database='aca')
 
 
     def get_prediction_states(self, tbegin):
@@ -338,7 +324,7 @@ class ACISStateBuilder(StateBuilder):
         bs_cmds = copy.copy(self.bs_cmds)
         bs_start_time = bs_cmds[0]['time']
         present_ofls_dir = copy.copy(self.backstop_file)
-        
+
         # So long as the earliest command in bs_cmds is after the state0
         # time, keep concatenating continuity commands to bs_cmds based upon
         # the type of load.
@@ -356,60 +342,59 @@ class ACISStateBuilder(StateBuilder):
         # The big while loop that backchains through previous loads and concatenates the
         # proper load sections to the review load.
         while state0['tstart'] < bs_start_time:
-    
+
             # Read the Continuity information of the present ofls directory
             cont_load_path, present_load_type, scs107_date = self.BSC.get_continuity_file_info(present_ofls_dir)
-    
-        #---------------------- NORMAL ----------------------------------------
+
+            #---------------------- NORMAL ----------------------------------------
             # If the load type is "normal" then grab the continuity command
             # set and concatenate those commands to the start of bs_cmds
             if present_load_type.upper() == 'NORMAL':
                 # Obtain the continuity load commands
                 cont_bs_cmds, cont_bs_name = self.BSC.get_bs_cmds(cont_load_path)
-    
+
                 # Combine the continuity commands with the bs_cmds
                 bs_cmds = self.BSC.CombineNormal(cont_bs_cmds, bs_cmds)
-        
+
                 # Reset the backstop collection start time for the While loop
                 bs_start_time = bs_cmds[0]['time']
                 # Now point the operative ofls directory to the Continuity directory
                 present_ofls_dir = cont_load_path
-        
-        #---------------------- TOO ----------------------------------------
+
+            #---------------------- TOO ----------------------------------------
             # If the load type is "too" then grab the continuity command
             # set and concatenate those commands to the start of bs_cmds
             elif present_load_type.upper() == 'TOO':
-                 # Obtain the continuity load commands
+                # Obtain the continuity load commands
                 cont_bs_cmds, cont_bs_name = self.BSC.get_bs_cmds(cont_load_path)
-    
+
                 # Combine the continuity commands with the bs_cmds
                 bs_cmds = self.BSC.CombineTOO(cont_bs_cmds, bs_cmds)
-                
+
                 # Reset the backstop collection start time for the While loop
                 bs_start_time = bs_cmds[0]['time']
                 # Now point the operative ofls directory to the Continuity directory
                 present_ofls_dir = cont_load_path
-        
-        
-        #---------------------- STOP ----------------------------------------
+
+            #---------------------- STOP ----------------------------------------
             # If the load type is "STOP" then grab the continuity command
             # set and concatenate those commands to the start of bs_cmds
             # Take into account the SCS-107 commands which shut ACIS down
             # and any LTCTI run
             elif present_load_type.upper() == 'STOP':
-        
+
                 # Obtain the continuity load commands
                 cont_bs_cmds, cont_bs_name = self.BSC.get_bs_cmds(cont_load_path)
-    
+
                 # CombineSTOP the continuity commands with the bs_cmds
                 bs_cmds = self.BSC.CombineSTOP(cont_bs_cmds, bs_cmds, scs107_date )
-                
+
                 # Reset the backstop collection start time for the While loop
                 bs_start_time = bs_cmds[0]['time']
                 # Now point the operative ofls directory to the Continuity directory
                 present_ofls_dir = cont_load_path
-        
-        #---------------------- SCS-107 ----------------------------------------
+
+            #---------------------- SCS-107 ----------------------------------------
             # If the load type is "STOP" then grab the continuity command
             # set and concatenate those commands to the start of bs_cmds
             # Take into account the SCS-107 commands which shut ACIS down
@@ -418,18 +403,17 @@ class ACISStateBuilder(StateBuilder):
                 # Obtain the continuity load commands
                 cont_bs_cmds, cont_bs_name = self.BSC.get_bs_cmds(cont_load_path)
                 # Store the continuity bs commands as a chunk in the chunk list
-        
+
                 # Obtain the CONTINUITY load Vehicle-Only file
                 vo_bs_cmds, vo_bs_name = self.BSC.get_vehicle_only_bs_cmds(cont_load_path)
-        
+
                 # Combine107 the continuity commands with the bs_cmds
                 bs_cmds = self.BSC.Combine107(cont_bs_cmds, vo_bs_cmds, bs_cmds, scs107_date )
-        
+
                 # Reset the backstop collection start time for the While loop
                 bs_start_time = bs_cmds[0]['time']
                 # Now point the operative ofls directory to the Continuity directory
                 present_ofls_dir = cont_load_path
-        
 
         # Convert the assembled backstop command history into commanded states
         # from state0 through the end of the Review Load backstop commands.
@@ -437,7 +421,7 @@ class ACISStateBuilder(StateBuilder):
         # time and then converts each relevant backstop command, in that resultant list,
         # into a pseudo-commanded states state
         states = cmd_states.get_states(state0, bs_cmds)
-    
+
         # Get rid of the 2099 placeholder stop date
         states[-1].datestop = bs_cmds[-1]['date']
         states[-1].tstop = bs_cmds[-1]['time']
@@ -447,41 +431,6 @@ class ACISStateBuilder(StateBuilder):
 
         return states, state0
 
-    def get_validation_states(self, datestart, datestop):
-        """
-        Get states for validation of the thermal model.
-
-        Parameters
-        ----------
-        datestart : string
-            The start date to grab states afterward.
-        datestop : string
-            The end date to grab states before.
-        """
-        datestart = DateTime(datestart).date
-        datestop = DateTime(datestop).date
-        self.logger.info('Getting commanded states between %s - %s' %
-                         (datestart, datestop))
-
-        # Get all states that intersect specified date range
-        cmd = """SELECT * FROM cmd_states
-                 WHERE datestop > '%s' AND datestart < '%s'
-                 ORDER BY datestart""" % (datestart, datestop)
-        self.logger.debug('Query command: %s' % cmd)
-        states = self.db.fetchall(cmd)
-        self.logger.info('Found %d commanded states' % len(states))
-
-        # Set start and end state date/times to match telemetry span.  Extend the
-        # state durations by a small amount because of a precision issue converting
-        # to date and back to secs.  (The reference tstop could be just over the
-        # 0.001 precision of date and thus cause an out-of-bounds error when
-        # interpolating state values).
-        states[0].tstart = DateTime(datestart).secs - 0.01
-        states[0].datestart = DateTime(states[0].tstart).date
-        states[-1].tstop = DateTime(datestop).secs + 0.01
-        states[-1].datestop = DateTime(states[-1].tstop).date
-
-        return states
 
 state_builders = {"sql": SQLStateBuilder,
                   "acis": ACISStateBuilder}

--- a/scripts/run_atc_tests
+++ b/scripts/run_atc_tests
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from importlib import import_module
+import argparse 
+
+all_models = ["dpa", "dea", "psmc", "acisfp", "fep1_mong",
+              "fep1_actel", bep_pcb"]
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--models', type=str)
+parser.add_argument('args', nargs=argparse.REMAINDER)
+
+args = parser.parse_args()
+
+if args.models is None:
+    models = all_models
+else:
+    models = args.which_models.split(",")
+
+for model in models:
+    model_check = import_module("{}_check".format(model))
+    model_check.test(args.args)
+    

--- a/scripts/run_atc_tests
+++ b/scripts/run_atc_tests
@@ -4,7 +4,7 @@ from importlib import import_module
 import argparse 
 
 all_models = ["dpa", "dea", "psmc", "acisfp", "fep1_mong",
-              "fep1_actel", bep_pcb"]
+              "fep1_actel", "bep_pcb"]
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--models', type=str)
@@ -20,4 +20,3 @@ else:
 for model in models:
     model_check = import_module("{}_check".format(model))
     model_check.test(args.args)
-    

--- a/scripts/update_atc_answers
+++ b/scripts/update_atc_answers
@@ -58,7 +58,7 @@ for model in models:
             print("Please enter y or n.")
         else:
             break
-    if response == "N":
+    if response == "Y":
         print("Updating the answers for the %s model." % model)
         gold_model_dir = os.path.join(gold_standard, model)
         new_model_dir = os.path.join(answer_dir, model)

--- a/scripts/update_atc_answers
+++ b/scripts/update_atc_answers
@@ -7,18 +7,18 @@ import shutil
 import glob
 from six.moves import input
 
-models = ["acisfp", "dea", "dpa", "psmc",
-          "fep1_mong", "fep1_actel",
-          "bep_pcb"]
+all_models = ["acisfp", "dea", "dpa", "psmc",
+              "fep1_mong", "fep1_actel",
+              "bep_pcb"]
 
 parser = argparse.ArgumentParser(description='A user-friendly script to update acis_thermal_check '
                                              'gold-standard answers.')
 parser.add_argument("answer_location", type=str, help='The location of the new answers.')
 parser.add_argument("--gold_standard", type=str, help='The location of the "gold standard" answers.',
                     default="/data/acis/thermal_model_tests")
-parser.add_argument("--which_models", type=str, help='Which models should have their answers updated. '
-                                                      'Should be passed in as a comma-separated list. If '
-                                                      'not specified, all answers found will be updated.')
+parser.add_argument("--models", type=str, help='Which models should have their answers updated. '
+                                               'Should be passed in as a comma-separated list. If '
+                                               'not specified, all answers found will be updated.')
 
 args = parser.parse_args()
 
@@ -32,18 +32,18 @@ if not os.path.exists(gold_standard):
 if not os.path.exists(answer_location):
     raise OSError("Cannot find the path %s!" % answer_location)
 
-if args.which_models is None:
-    which_models = os.listdir(answer_location)
+if args.models is None:
+    models = os.listdir(answer_location)
 else:
-    which_models = args.which_models.split(",")
+    models = args.models.split(",")
 
-if len(which_models) == 0:
+if len(models) == 0:
     raise OSError("No answers were found in %s or specified!" % answer_location)
 
 updated = []
 
-for model in which_models:
-    if model not in models:
+for model in models:
+    if model not in all_models:
         print("Directory %s not a model directory, so skipping." % model)
         continue
     answer_dir = os.path.join(answer_location, model)

--- a/scripts/update_atc_answers
+++ b/scripts/update_atc_answers
@@ -52,6 +52,7 @@ for model in models:
                       "the new answers %s!" % answer_dir)
     while True:
         response = input("I'm about to update the answers for model %s. Is that ok? [y/N]" % model)
+        response = response.upper()
         if response == "":
             response = "N"
         if response not in ["Y","N"]:

--- a/scripts/update_atc_answers
+++ b/scripts/update_atc_answers
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import argparse
+import os
+import shutil
+import glob
+from six.moves import input
+
+models = ["acisfp", "dea", "dpa", "psmc",
+          "fep1_mong", "fep1_actel",
+          "bep_pcb"]
+
+parser = argparse.ArgumentParser(description='A user-friendly script to update acis_thermal_check '
+                                             'gold-standard answers.')
+parser.add_argument("answer_location", type=str, help='The location of the new answers.')
+parser.add_argument("--gold_standard", type=str, help='The location of the "gold standard" answers.',
+                    default="/data/acis/thermal_model_tests")
+parser.add_argument("--which_models", type=str, help='Which models should have their answers updated. '
+                                                      'Should be passed in as a comma-separated list. If '
+                                                      'not specified, all answers found will be updated.')
+
+args = parser.parse_args()
+
+gold_standard = os.path.abspath(args.gold_standard)
+answer_location = os.path.abspath(args.answer_location)
+
+if not os.path.exists(gold_standard):
+    raise OSError("Cannot find the \"gold standard\" answers located at "
+                  "%s!" % gold_standard)
+
+if not os.path.exists(answer_location):
+    raise OSError("Cannot find the path %s!" % answer_location)
+
+if args.which_models is None:
+    which_models = os.listdir(answer_location)
+else:
+    which_models = args.which_models.split(",")
+
+if len(which_models) == 0:
+    raise OSError("No answers were found in %s or specified!" % answer_location)
+
+updated = []
+
+for model in which_models:
+    if model not in models:
+        print("Directory %s not a model directory, so skipping." % model)
+        continue
+    answer_dir = os.path.join(answer_location, model)
+    if not os.path.exists(answer_dir):
+        raise OSError("Cannot find the directory containing "
+                      "the new answers %s!" % answer_dir)
+    while True:
+        response = input("I'm about to update the answers for model %s. Is that ok? [y/N]" % model)
+        if response == "":
+            response = "N"
+        if response not in ["Y","N"]:
+            print("Please enter y or n.")
+        else:
+            break
+    if response == "N":
+        print("Updating the answers for the %s model." % model)
+        gold_model_dir = os.path.join(gold_standard, model)
+        new_model_dir = os.path.join(answer_dir, model)
+        old_answers = glob.glob("%s.[0-9][0-9][0-9]" % model)
+        old_answers.sort()
+        if len(old_answers) == 0:
+            print("No old answers are backed up, so we're creating the first backup.")
+            latest_answer = 1
+        else:
+            latest_answer = int(old_answers[-1].split(".")[-1]) + 1
+            print("Incrementing latest answers for %s to %d." % (model, latest_answer))
+        old_model_dir = os.path.join(answer_dir, "%s.%03d" % (model, latest_answer))
+        shutil.copytree(gold_model_dir, old_model_dir)
+        shutil.rmtree(gold_model_dir)
+        shutil.copytree(new_model_dir, gold_model_dir)
+        updated.append(model)
+    else:
+        print("Ok, we will not update the answers for the %s model." % model)
+
+if len(updated) == 0:
+    raise RuntimeError("No answers were updated, so something must have gone wrong!")
+else:
+    print("The answers for the following models have been updated: ")
+    print(",".join(updated))

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import glob
 from acis_thermal_check import __version__
 
 templates = glob.glob("templates/*")
+scripts = glob.glob("scripts/*")
 
 url = 'https://github.com/acisops/acis_thermal_check/tarball/{}'.format(__version__)
 
@@ -16,6 +17,7 @@ setup(name='acis_thermal_check',
       url='http://github.com/acisops/acis_thermal_check',
       download_url=url,
       data_files=[('templates', templates)],
+      scripts=scripts,
       include_package_data=True,
       classifiers=[
           'Intended Audience :: Science/Research',


### PR DESCRIPTION
This is a refactoring of the testing infrastructure for `acis_thermal_check`. The goal here is to make regression testing for the thermal models easier to run and for failures of tests on individual loads to be cleanly separated from other tests.

A broad overview of these changes are:

* Separate out the `py.test` options structure into a separate file so that it can be imported more easily from a specific model software package such as `dpa_check`.
* Loads are now classified into only two different categories, "normal" and "interrupt", instead of the previous three.
* Models are run and outputs are stored first, and testing takes place on a load-by-load basis in a separate step.
* Functions for prediction and validation tests are separated out.
* Allow different JSON model spec files (other than the current default) to be used for tests.
* Test the `earth_solid_angles.dat` file in the focal plane model predictions.
* A brand new test type which checks that loads which _should_ report thermal violations do so correctly.
* Added a command-line script for running all of the model tests in one go.
* Added an interactive command-line script for copying new answers that have been generated from a test run to the ACIS "gold standard" location.

Minor changes were also required for the `ACISThermalCheck` object itself to support these changes to the testing. The most important one is a keyword argument to modify the thermal limits in the model at run-time. This is for testing only and is not accessible via the normal command-line runs of the thermal models. We also require now that pickle files are written with `protocol=2` to enable Python 2/3 interoperability. 

An example of how to use these tests from `dpa_check` can be seen at https://github.com/acisops/dpa_check/pull/15.