### PR TITLE
Documentation for acis_thermal_check

### DIFF
--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -357,8 +357,7 @@ def get_options(name, model_path, opts=None):
     parser.add_argument("--verbose", type=int, default=1,
                         help="Verbosity (0=quiet, 1=normal, 2=debug)")
     parser.add_argument("--T-init", type=float,
-                        help="Starting temperature (degC or degF, depending on the model). "
-                             "Default is to compute it from telemetry.")
+                        help="Starting temperature (degC). Default is to compute it from telemetry.")
     parser.add_argument("--state-builder", default="acis",
                         help="StateBuilder to use (sql|acis). Default: acis")
     parser.add_argument("--nlet_file",

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -334,7 +334,7 @@ def get_options(name, model_path, opts=None):
     parser = ArgumentParser()
     parser.set_defaults()
     parser.add_argument("--outdir", default="out", help="Output directory. If it does not "
-                                                        "exist it will be created.Default: 'out'")
+                                                        "exist it will be created. Default: 'out'")
     parser.add_argument("--backstop_file", help="Path to the backstop file. If a directory, "
                                                 "the backstop file will be searched for within "
                                                 "this directory. Default: None")

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -333,7 +333,8 @@ def get_options(name, model_path, opts=None):
     from argparse import ArgumentParser
     parser = ArgumentParser()
     parser.set_defaults()
-    parser.add_argument("--outdir", default="out", help="Output directory. Default: 'out'")
+    parser.add_argument("--outdir", default="out", help="Output directory. If it does not "
+                                                        "exist it will be created.Default: 'out'")
     parser.add_argument("--backstop_file", help="Path to the backstop file. If a directory, "
                                                 "the backstop file will be searched for within "
                                                 "this directory. Default: None")

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -361,12 +361,12 @@ def get_options(name, model_path, opts=None):
                              "Default is to compute it from telemetry.")
     parser.add_argument("--state-builder", default="acis",
                         help="StateBuilder to use (sql|acis). Default: acis")
-    parser.add_argument("--version", action='store_true', help="Print version")
-    # Argument pointing to the NLET file the model should use for this run
     parser.add_argument("--nlet_file",
                         default='/data/acis/LoadReviews/NonLoadTrackedEvents.txt',
                         help="Full path to the Non-Load Event Tracking file that should be "
                              "used for this model run.")
+    parser.add_argument("--version", action='store_true', help="Print version")
+
     if opts is not None:
         for opt_name, opt in opts:
             parser.add_argument("--%s" % opt_name, **opt)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,6 +20,7 @@
 import os
 import sys
 import acis_thermal_check
+from datetime import datetime
 # sys.path.insert(0, os.path.abspath('.'))
 
 sys.path.insert(0, os.path.abspath('../../'))
@@ -44,8 +45,8 @@ html_theme_options = dict(
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode']
+              'sphinx.ext.intersphinx',
+              'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -59,9 +60,11 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
+d = datetime.now()
+
 # General information about the project.
 project = 'acis_thermal_check'
-copyright = '2017, John ZuHone'
+copyright = f'{d.year}, CXC/ACIS Operations Team'
 author = 'John ZuHone'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/developing_models.rst
+++ b/doc/source/developing_models.rst
@@ -7,7 +7,9 @@ To develop a new thermal model for use with ``acis_thermal_check``, the
 following steps should be followed. A new model needs the following:
 
 * A subclass of the ``ACISThermalCheck`` class, e.g. ``DPACheck``.
-* This subclass should have 
+* This subclass should have information about model validation limits,
+  histogram limits, and a method called ``_calc_model_supp`` which implements
+  additional model components specific to this model. 
 * Testing needs to be set up. 
 
 Developing a new thermal model to use with ``acis_thermal_check`` is fairly

--- a/doc/source/developing_models.rst
+++ b/doc/source/developing_models.rst
@@ -521,7 +521,8 @@ like this:
         dpa_rt.check_violation_reporting("JUL3018A", answer_data,
                                          answer_store=answer_store)
 
-After the test is run, the JSON file will look like this:
+After the test is run with the ``--answer_store`` flag set 
+(see :ref:`test-suite`), the JSON file will look like this:
 
 .. code-block:: json
 

--- a/doc/source/developing_models.rst
+++ b/doc/source/developing_models.rst
@@ -483,7 +483,27 @@ is a test of that. The example for the 1DPAMZT model is shown below:
 
 Finally, tests of thermal violation flagging should also be generated. These 
 tests check if violations of planning limits during model predictions are
-flagged appropriately. They test a single load, and 
+flagged appropriately. They test a single load, and require a new JSON file 
+to be stored in the ``tests/answers`` subdirectory which contain the details
+of the test. For this, you need to select a load, and then create a JSON file
+which contains the ``run_start`` for the model (this is to ensure 
+reproducibility) and new ``limits`` for the model run, to ensure that a 
+violation actually occurs. These should be set a few degrees lower than the 
+real limits. For the 1DPAMZT model, the file is named ``JUL3018A_viol.json``
+and looks like this:
+
+.. code-block:: json
+
+    {
+        "run_start": "2018:205:00:42:38.816",
+        "limits": {
+            "yellow_hi": 37.2,
+            "plan_limit_hi": 35.2
+        }
+    }
+
+The JUL3018A load was selected for this test. The script to run this test looks
+like this:
 
 .. code-block:: python
 
@@ -500,3 +520,35 @@ flagged appropriately. They test a single load, and
                                    "JUL3018A_viol.json")
         dpa_rt.check_violation_reporting("JUL3018A", answer_data,
                                          answer_store=answer_store)
+
+After the test is run, the JSON file will look like this:
+
+.. code-block:: json
+
+    {
+        "datestarts": [
+            "2018:212:16:23:26.816",
+            "2018:213:14:42:46.816",
+            "2018:215:04:09:34.816"
+        ],
+        "datestops": [
+            "2018:212:17:29:02.816",
+            "2018:213:16:10:14.816",
+            "2018:215:05:15:10.816"
+        ],
+        "temps": [
+            "35.89",
+            "35.89",
+            "35.72"
+        ],
+        "run_start": "2018:205:00:42:38.816",
+        "limits": {
+            "yellow_hi": 37.2,
+            "plan_limit_hi": 35.2
+        }
+    }
+
+Note that the start and stop times of the violations and the values of the
+maximum temperatures themselves have been added to the JSON file. These are
+the values which will be tested, as well as whether or not the page flags a
+violation. 

--- a/doc/source/how_it_works.rst
+++ b/doc/source/how_it_works.rst
@@ -1,0 +1,69 @@
+How ``acis_thermal_check`` Works
+--------------------------------
+
+The Model Check Tools
+=====================
+
+``acis_thermal_check`` is a library that is utilized by various software tools
+to run ACIS thermal models and produce web pages for prediction and validation. 
+The current tools which use ``acis_thermal_check`` for load review are:
+
+* ``dpa_check`` for the 1DPAMZT model
+* ``dea_check`` for the 1DEAMZT model
+* ``psmc_check`` for the 1PDEAAT model
+* ``acisfp_check`` for the ACIS Focal Plane model
+
+These tools run models for the BEP and FEP models which are not currently used
+for flight, but are still checked at every load review:
+
+* ``fep1_mong_check`` for the FEP1 Mongoose model
+* ``fep1_actel_check`` for the FEP1 Actel model
+* ``bep_pcb_check`` for the BEP PCB model
+
+Directions on how to run these models can be found at :ref:`running-models`. 
+
+The Web Pages
+=============
+
+The web pages that are produced by ``acis_thermal_check`` generate plots and
+other information for prediction and validation. 
+
+Prediction plots are used to show the thermal behavior of a particular 
+component for a load. If a violation of a planning limit occurs, these 
+violations are flagged on the page, including the time of the violation and 
+the maximum or minimum temperature reached. 
+
+Validation plots are used to compare model outputs of the temperature and other
+quantities vs. actual past data which was telemetered from the spacecraft. 
+Histograms of data - model errors are shown and error quantiles are also listed.
+
+Example web pages for the most recent load review can be found
+`here <https://asc.harvard.edu/acis/Thermal/index.html>`_. 
+
+The ``StateBuilder`` Class
+==========================
+
+The inputs for a thermal model include commanded states, such as attitude
+quaternions, CCD count, FEP count, etc. For the load under review, these are
+determined from the backstop file for that load. However, given the fact that we
+need to begin the thermal model propagation before the load starts to "wash out"
+any errors in the initial condition, we need to begin the propagation before the
+load starts. In order to do that, we need the commanded states. 
+``acis_thermal_check`` provides two different ways to construct a state history
+in the ``StateBuilder`` class: the "ACIS" ``StateBuilder`` (the default) and the
+"SQL" ``StateBuilder``. The first case constructs a history of states using a
+series of backstop files from the previous loads, as well as any information
+from the Non-Load Event Tracker (NLET) file in case of an interrupted load. This
+``StateBuilder`` requires the full ``/data/acis/LoadReviews`` structure, at 
+least for the last several loads. The "SQL" state builder uses the commanded 
+states database to construct a history of states. 
+
+In theory, both ``StateBuilder`` types should give the same results if the
+sources for the states are fully updated. In most situations, this should be the
+case. However, if one is responding to an interrupt condition, the "ACIS" 
+``StateBuilder`` will be more up-to-date and accurate, since once a non-load 
+event such as a safing action or a long ECS run occurs, the ACIS on-duty person
+should update the NLET file. See 
+`here <https://asc.harvard.edu/acis/memos/webpage/NonLoadEventTracker.html>`_
+and `here <When To Use the Non-Load Event Tracking GUI (Under Construction)>`_
+for more information on how to do this. 

--- a/doc/source/how_it_works.rst
+++ b/doc/source/how_it_works.rst
@@ -1,3 +1,5 @@
+.. _how-it-works:
+
 How ``acis_thermal_check`` Works
 --------------------------------
 
@@ -65,5 +67,5 @@ case. However, if one is responding to an interrupt condition, the "ACIS"
 event such as a safing action or a long ECS run occurs, the ACIS on-duty person
 should update the NLET file. See 
 `here <https://asc.harvard.edu/acis/memos/webpage/NonLoadEventTracker.html>`_
-and `here <When To Use the Non-Load Event Tracking GUI (Under Construction)>`_
+and `here <https://cxc.cfa.harvard.edu/acis/memos/webpage/WhenToUseNLETGUI.html>`_
 for more information on how to do this. 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -32,6 +32,7 @@ Documentation Contents
    :maxdepth: 2
        
    install
+   how_it_works
    running_models
    developing_models
    test_suite

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -31,5 +31,23 @@ the source directory itself:
 
 All of the above presumes that you have write access to the Python stack which 
 you are using. If you do not (e.g., it is flight Ska), then you can still 
-install and develop a custom version of the package. You can do that by either
+install and/or develop a custom version of the package. You can do that by using 
+the ``--user`` flag in addition to either of the above options:
+
+.. code-block:: bash
+
+    [~]$ python setup.py install --user
+
+or 
+
+.. code-block:: bash
+
+    [~]$ python setup.py develop --user
+
+This installs packages under the ``$HOME/.local`` directory structure. However, it 
+is much more desirable to test in your own Ska environment. For information on how 
+to create one, go `here <https://github.com/sot/skare3/wiki/Ska3-runtime-environment-for-users>`_. 
+
+
+
 

--- a/doc/source/running_models.rst
+++ b/doc/source/running_models.rst
@@ -12,8 +12,7 @@ Base Command-Line Arguments
 
 The following is a brief description of the base collection of command-line 
 arguments accepted by a model using ``acis_thermal_check``. Additional arguments
-may be added by individual models in the call to 
-:func:`~acis_thermal_check.utils.get_options`, as further detailed in
+may be added by individual models in the call to, as further detailed in
 :ref:`developing-models`. 
 
 .. code-block:: text
@@ -37,19 +36,20 @@ may be added by individual models in the call to
   --interrupt           Set this flag if this is an interrupt load.
   --traceback TRACEBACK
                         Enable tracebacks. Default: True
+  --pred-only           Only make predictions. Default: False
   --verbose VERBOSE     Verbosity (0=quiet, 1=normal, 2=debug)
-  --T-init T_INIT       Starting temperature (degC or degF, depending on the
-                        model). Default is to compute it from telemetry.
-  --cmd-states-db CMD_STATES_DB
-                        Commanded states database server (sybase|sqlite).
-                        Default: sybase
+  --T-init T_INIT       Starting temperature (degC). Default is to compute it 
+                        from telemetry.
   --state-builder STATE_BUILDER
                         StateBuilder to use (legacy|acis). Default:
                         legacy
+  --nlet_file NLET_FILE
+                        Full path to the Non-Load Event Tracking that should
+                        be used for this model run
   --version             Print version
 
-Running Thermal Models for a Load Review
-++++++++++++++++++++++++++++++++++++++++
+Running Thermal Models: Examples
+++++++++++++++++++++++++++++++++
 
 The most common application for any model based on ``acis_thermal_check`` is to
 run the model for a load. In this case, the minimum command-line arguments are
@@ -57,34 +57,39 @@ the path to the backstop file and the output directory for the files:
 
 .. code-block:: bash
 
-    [~]$ dpa_check --backstop_file=/data/acis/LoadReviews/2017/OCT1617 --outdir=dpa_oct1617 
+    [~]$ dpa_check --backstop_file=/data/acis/LoadReviews/2017/OCT1617/ofls --outdir=dpa_oct1617 
 
-If the load being reviewed is a return to science from a shutdown, or a replan
-due to a TOO, or any other interrupt, the thermal model should be run with the
-``--interrupt`` flag to ensure commanded states are properly determined:
+In this case, we only supplied the directory containing the backstop file, 
+assuming that there is only one present. If the load being reviewed is a return 
+to science from a shutdown, or a replan due to a TOO, or any other interrupt, 
+the thermal model should be run with the ``--interrupt`` flag to ensure 
+commanded states are properly determined:
 
 .. code-block:: bash
 
-    [~]$ dpa_check --backstop_file=/data/acis/LoadReviews/2017/AUG3017 --interrupt --outdir=dpa_aug3017
+    [~]$ psmc_check --backstop_file=/data/acis/LoadReviews/2017/AUG3017/ofls --interrupt --outdir=psmc_aug3017
 
 By default, the initial temperature for the model will be set using an average 
 of telemetry in a few minutes around the run start time. However, the model can
 be started with a specific temperature value using the ``--T-init`` argument, 
-which is assumed to be in the same units of the temperature in the model 
-(degrees C or F):
+which is assumed to be in degrees C:
 
 .. code-block:: bash
 
-    [~]$ dpa_check --backstop_file=/data/acis/LoadReviews/2017/OCT1617 --outdir=dpa_oct1617 --T-init=22.0
+    [~]$ acisfp_check --backstop_file=/data/acis/LoadReviews/2017/OCT1617/ofls --outdir=acisfp_oct1617 --T-init=22.0
 
-One can also choose to access the commanded states database via Sybase or 
-SQLite. The former only works with Python 2, so if Python 3 is used, the latter
-will be chosen automatically. To choose which one to use, set the 
-``--cmd-states-db`` flag:
+If necessary, thermal model runs can be run for a particular load for predictions only,
+using the ``--pred-only`` flag:
 
 .. code-block:: bash
 
-    [~]$ dpa_check --backstop_file=/data/acis/LoadReviews/2017/OCT1617 --outdir=dpa_oct1617 --cmd-states-db=sqlite
+    [~]$ dea_check --backstop_file=/data/acis/LoadReviews/2017/AUG3017/ofls --outdir=dea_aug3017 --pred-only
 
-Running Thermal Models for Validation Only
-++++++++++++++++++++++++++++++++++++++++++
+Finally, if one wishes to run validation without prediction for a specific load,
+simply omit the ``backstop_file`` argument. It may make sense here to supply a 
+``run_start`` argument, if one wants a different time than the current time to 
+validate:
+
+.. code-block:: bash
+
+    [~]$ dpa_check --run-start=2019:300:12:50:00 --outdir=validate_dec2019

--- a/doc/source/running_models.rst
+++ b/doc/source/running_models.rst
@@ -17,7 +17,8 @@ may be added by individual models in the call to, as further detailed in
 
 .. code-block:: text
 
-  --outdir OUTDIR       Output directory. Default: 'out'
+  --outdir OUTDIR       Output directory. If it does not exist it will be
+                        created. Default: 'out' 
   --backstop_file BACKSTOP_FILE
                         Path to the backstop file. If a directory, the
                         backstop file will be searched for within this

--- a/doc/source/test_suite.rst
+++ b/doc/source/test_suite.rst
@@ -9,8 +9,8 @@ outputs for a number of load weeks. This section describes the test suite, how
 to run it, how to add new loads for testing, and how to update the gold standard
 model answers.
 
-A Overview of ``acis_thermal_check`` Regression Testing
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+An Overview of ``acis_thermal_check`` Regression Testing
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 When an ``acis_thermal_check`` model is run, it produces numerical outputs for 
 model prediction and validation in addition to the plots and tables on the 
@@ -19,12 +19,10 @@ numerical output from model runs against a set of "gold standard" stored
 outputs. The idea is that code developments should not change the values 
 compared to those stored in the gold standard, or if they do, that the reasons
 for the changes are understood and deemed necessary (e.g., you found
-a bug, you updated the model specification, or you added a feature to 
-a model). Though this means that the gold standard answers might 
-change regularly (so maybe more of a floating currency), the idea is to
-track the effect of code changes in a systematic way and flag those 
-changes which are not expected to change results but do, so that bugs
-can be identified and fixed before merging the new code into master. 
+a bug, you added a feature to a model, etc.). The idea is to track the effect
+of code changes in a systematic way and flag those changes which are not 
+expected to change results but do, so that bugs can be identified and fixed 
+before merging the new code into master. 
 
 Running the Test Suite for a Particular Model
 +++++++++++++++++++++++++++++++++++++++++++++
@@ -33,11 +31,13 @@ There are a few equivalent ways to invoke the ``acis_thermal_check``
 tests for a given model. 
 
 If you are making changes to a model, you can go to the root of the model code
-directory (e.g., ``dpa_check``) and just run ``py.test``:
+directory (e.g., ``dpa_check``) and run ``py.test`` like so:
 
 .. code-block:: bash
 
-    [~]$ py.test -s 
+    [~]$ cd ~/Source/dpa_check
+
+    [~]$ py.test -s .
 
 The ``-s`` flag is optionally included so that the output has maximum verbosity.
 
@@ -47,23 +47,19 @@ Adding the Basic Test Suite to a New Model
 Updating the "Gold Standard" Answers
 ++++++++++++++++++++++++++++++++++++
 
-If the regression tests failed to pass for one or more models, 
-but you understand the failures and they are due to changes you
-made which need to become part of the software (such as a bugfix
-or a feature enhancement), then the "gold standard" answers need 
-to be updated. In theory, updating these could be as simple as 
-generating new answers and copying them into the appropriate
-directory, but to be safe there is a script, ``update_atc_answers``,
-which handles this for you in a transparent way with prompts and
-outputs to screen so that you are sure you are doing the right thing
-and that you see what is actually being done. 
+New "gold standard" answers for a given model may need to be generated for two
+reasons. First, you may be making a new model and need to generate the initial 
+set of answers. Second, if you are updating ACIS code and the regression tests 
+failed to pass for one or more models, but the failures are understood and they 
+are due to changes you made which need to become part of the software (such as 
+a bugfix or a feature enhancement), then the "gold standard" answers need to be
+updated. 
 
-First, you should change your group to ``acisops``:
+To generate new answers, go to the root of the model code directory that you are
+working in, and run ``py.test``, with the ``--answer_store`` argument:
 
 .. code-block:: bash
-    
-    [~]$ newgrp acisops
 
-This enables you to write to the set of thermal model gold standard answers
-which are owned by the user ``acisdude`` under the group ``acisops``. These 
-are located in the directory ``/data/acis/thermal_model_tests``. 
+    [~]$ cd ~/Source/dpa_check
+
+    [~]$ py.test -s . --answer_store

--- a/doc/source/test_suite.rst
+++ b/doc/source/test_suite.rst
@@ -1,4 +1,4 @@
-.. _test-suite:
+.. _test_suite:
 
 Using the ``acis_thermal_check`` Regression Testing
 ---------------------------------------------------
@@ -19,15 +19,20 @@ numerical output from model runs against a set of "gold standard" stored
 outputs. The idea is that code developments should not change the values 
 compared to those stored in the gold standard, or if they do, that the reasons
 for the changes are understood and deemed necessary (e.g., you found
-a bug, you added a feature to a model, etc.). The idea is to track the effect
+a bug, you added a feature to a model, etc.). This allows us to track the effect
 of code changes in a systematic way and flag those changes which are not 
 expected to change results but do, so that bugs can be identified and fixed 
 before merging the new code into master. 
 
+A model specification file in JSON format is set aside for testing, and can be
+different from the one currently in use for thermal models. It should only be
+updated sparingly, usually if there are major changes to the structure of a 
+model.
+
 Running the Test Suite for a Particular Model
 +++++++++++++++++++++++++++++++++++++++++++++
 
-There are a few equivalent ways to invoke the ``acis_thermal_check``
+There are two equivalent ways to invoke the ``acis_thermal_check``
 tests for a given model. 
 
 If you are making changes to a model, you can go to the root of the model code
@@ -39,13 +44,18 @@ directory (e.g., ``dpa_check``) and run ``py.test`` like so:
 
     [~]$ py.test -s .
 
-The ``-s`` flag is optionally included so that the output has maximum verbosity.
+The ``-s`` flag is optionally included here so that the output has maximum verbosity.
 
-Adding the Basic Test Suite to a New Model
-++++++++++++++++++++++++++++++++++++++++++
+You can also import any model package from an interactive Python session and run the 
+``test()`` method on it:
 
-Updating the "Gold Standard" Answers
-++++++++++++++++++++++++++++++++++++
+.. code-block:: pycon
+
+    >>> import acisfp_check
+    >>> acisfp_check.test()
+
+Updating the "Gold Standard" Answers for a Particular Model
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 New "gold standard" answers for a given model may need to be generated for two
 reasons. First, you may be making a new model and need to generate the initial 
@@ -63,3 +73,7 @@ working in, and run ``py.test``, with the ``--answer_store`` argument:
     [~]$ cd ~/Source/dpa_check
 
     [~]$ py.test -s . --answer_store
+
+This will overwrite the old answers, but since they are also under git version 
+control you will be able to check any differences before committing the new
+answers. 


### PR DESCRIPTION
## Description

This PR implements documentation for `acis_thermal_check`, including how to run an `acis_thermal_check` application, develop a new one, and test it. 

A compiled example of the documentation is present at http://cxc.harvard.edu/acis/acis_thermal_check. 

This PR also cleans up some of the usage text in the `ArgumentParser` object used by `acis_thermal_check` applications. 

## Testing

- [x] Passes unit tests on MacOS