### PR TITLE
SHINY: support migration from Chandra.cmd_states / Ska.ParseCM to kadi

### DIFF
--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -503,7 +503,8 @@ class ACISThermalCheck(object):
         states_table['pitch'].format = '%.2f'
         states_table['tstart'].format = '%.2f'
         states_table['tstop'].format = '%.2f'
-        states_table.write(outfile, format='ascii', delimiter='\t', overwrite=True)
+        states_table.write(outfile, format='ascii', delimiter='\t', overwrite=True,
+                           fast_writer=False)
 
     def write_temps(self, outdir, times, temps):
         """

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -9,10 +9,11 @@ from collections import OrderedDict, defaultdict
 import re
 import time
 import pickle
+import getpass
 import numpy as np
 import Ska.DBI
 import Ska.Numpy
-from Chandra.Time import DateTime, date2secs, secs2date
+from Chandra.Time import DateTime, date2secs, secs2date, use_noon_day_start
 import matplotlib.pyplot as plt
 from Ska.Matplotlib import cxctime2plotdate, \
     pointpair, plot_cxctime
@@ -33,6 +34,9 @@ op_map = {"greater": ">",
           "greater_equal": ">=",
           "less": "<",
           "less_equal": "<="}
+
+
+use_noon_day_start()
 
 
 class ACISThermalCheck(object):
@@ -78,15 +82,15 @@ class ACISThermalCheck(object):
         names understood by Xija to MSIDs.
     flag_cold_viols : boolean, optional
         If set, violations for the lower planning limit will be
-        checked for and flagged, and 
+        checked for and flagged, and
     hist_ops : list of strings, optional
         This sets the operations which will be used to create the
         error histograms, e.g., including only temperatures above
         or below a certain value. Should be a list equal to the
-        length of the *hist_limit* length. For example, 
+        length of the *hist_limit* length. For example,
         ["greater_equal", "greater_equal"] for two histogram limits.
-        Options are "greater", "less", "greater_equal", 
-        "less_equal" Defaults to "greater_equal" for all values 
+        Options are "greater", "less", "greater_equal",
+        "less_equal" Defaults to "greater_equal" for all values
         in *hist_limit*.
     """
     def __init__(self, msid, name, validation_limits, hist_limit,
@@ -331,11 +335,11 @@ class ACISThermalCheck(object):
         tstart : float
             The start time of the model run.
         tstop : float
-            The end time of the model run. 
+            The end time of the model run.
         state0 : dict, optional
             This is used to set the initial temperature. It's a dictionary
-            indexed by MSID name so that more than one can be input if 
-            necessary. 
+            indexed by MSID name so that more than one can be input if
+            necessary.
         """
         import xija
         model = xija.ThermalModel(self.name, start=tstart, stop=tstop,
@@ -570,7 +574,7 @@ class ACISThermalCheck(object):
 
     def make_prediction_plots(self, outdir, states, temps, load_start):
         """
-        Make plots of the thermal prediction as well as associated 
+        Make plots of the thermal prediction as well as associated
         commanded states.
 
         Parameters
@@ -592,13 +596,13 @@ class ACISThermalCheck(object):
         # Start time of loads being reviewed expressed in units for plotdate()
         load_start = cxctime2plotdate([load_start])[0]
         # Value for left side of plots
-        plot_start = max(load_start-2.0, 
+        plot_start = max(load_start-2.0,
                          cxctime2plotdate([times[0]])[0])
 
         w1 = None
         mylog.info('Making temperature prediction plots')
         plots[self.name] = plot_two(fig_id=1, x=times, y=temps[self.name],
-                                    x2=times, 
+                                    x2=times,
                                     y2=self.predict_model.comp["pitch"].mvals,
                                     title=self.msid.upper(), xmin=plot_start,
                                     xlabel='Date', ylabel='Temperature (C)',
@@ -609,7 +613,7 @@ class ACISThermalCheck(object):
         ymax = max(self.yellow_hi+1, ymax)
         plots[self.name]['ax'].axhline(self.yellow_hi, linestyle='-', color='gold',
                                        linewidth=2.0)
-        plots[self.name]['ax'].axhline(self.plan_limit_hi, linestyle='-', 
+        plots[self.name]['ax'].axhline(self.plan_limit_hi, linestyle='-',
                                        color='C2', linewidth=2.0)
         if self.flag_cold_viols:
             ymin = min(self.yellow_lo-1, ymin)
@@ -638,11 +642,11 @@ class ACISThermalCheck(object):
     def get_histogram_mask(self, tlm, limits):
         """
         This method determines which values of telemetry
-        should be used to construct the temperature 
-        histogram plots, using limits provided by the 
+        should be used to construct the temperature
+        histogram plots, using limits provided by the
         calling program to mask the array via a logical
-        operation. The default implementation is to plot 
-        values above a certain limit. This method may be 
+        operation. The default implementation is to plot
+        values above a certain limit. This method may be
         overriden by subclasses of ACISThermalCheck.
 
         Parameters
@@ -677,7 +681,7 @@ class ACISThermalCheck(object):
         outdir : string
             The directory to write outputs to.
         run_start : string
-            The starting date/time of the run. 
+            The starting date/time of the run.
         """
         start = tlm['date'][0]
         stop = tlm['date'][-1]
@@ -749,7 +753,7 @@ class ACISThermalCheck(object):
             ticklocs, fig, ax = plot_cxctime(model.times, tlm[msid] / scale,
                                              fig=fig, ls='-', lw=2, color=thermal_blue)
             if np.any(~good_mask):
-                ticklocs, fig, ax = plot_cxctime(model.times[~good_mask], 
+                ticklocs, fig, ax = plot_cxctime(model.times[~good_mask],
                                                  tlm[msid][~good_mask] / scale,
                                                  fig=fig, fmt='.c')
             ax.set_title(msid.upper() + ' validation; data: blue, model: red')
@@ -760,7 +764,7 @@ class ACISThermalCheck(object):
             for rz in rzs:
                 ptimes = cxctime2plotdate([rz.tstart, rz.tstop])
                 for ptime in ptimes:
-                    ax.axvline(ptime, ls='--', color='C2', 
+                    ax.axvline(ptime, ls='--', color='C2',
                                linewidth=2, zorder=-10)
             # Add horizontal lines for the planning and caution limits
             # or the limits for the focal plane model. Make sure we can
@@ -775,9 +779,9 @@ class ACISThermalCheck(object):
                                linewidth=2)
                     ymax = max(acis_i+1, ymax)
                 else:
-                    ax.axhline(self.yellow_hi, linestyle='-', color='gold', 
+                    ax.axhline(self.yellow_hi, linestyle='-', color='gold',
                                zorder=-8, linewidth=2)
-                    ax.axhline(self.plan_limit_hi, linestyle='-', color='C2', 
+                    ax.axhline(self.plan_limit_hi, linestyle='-', color='C2',
                                zorder=-8, linewidth=2)
                     ymax = max(self.yellow_hi+1, ymax)
                     if self.flag_cold_viols:
@@ -923,7 +927,7 @@ class ACISThermalCheck(object):
         Parameters
         ----------
         outdir : string
-            The path to the directory to which the outputs will be 
+            The path to the directory to which the outputs will be
             written to.
         proc : dict
             A dictionary of general information used in the output
@@ -934,7 +938,7 @@ class ACISThermalCheck(object):
         dirname = os.path.dirname(docutils.writers.html4css1.__file__)
         shutil.copy2(os.path.join(dirname, 'html4css1.css'), outdir)
 
-        shutil.copy2(os.path.join(TASK_DATA, 'acis_thermal_check', 'templates', 
+        shutil.copy2(os.path.join(TASK_DATA, 'acis_thermal_check', 'templates',
                                   'acis_thermal_check.css'), outdir)
 
         # Spawn a shell and call rst2html to generate HTML from the reST.
@@ -960,7 +964,7 @@ class ACISThermalCheck(object):
     def write_index_rst(self, outdir, context):
         """
         Make output text (in ReST format) in outdir, using jinja2
-        to fill out the template. 
+        to fill out the template.
 
         Parameters
         ----------
@@ -1009,7 +1013,7 @@ class ACISThermalCheck(object):
         config_logging(args.outdir, args.verbose)
 
         # Store info relevant to processing for use in outputs
-        proc = dict(run_user=os.environ['USER'],
+        proc = dict(run_user=getpass.getuser(),
                     run_time=time.ctime(),
                     errors=[],
                     msid=self.msid.upper(),

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1022,8 +1022,7 @@ class ACISThermalCheck(object):
         if self.msid != "fptemp":
             proc["msid_limit"] = self.yellow_hi - self.margin
         # Figure out the MD5 sum of model spec file
-        model_json = json.dumps(args.model_spec, sort_keys=True, indent=4).encode("utf-8")
-        md5sum = hashlib.md5(model_json).hexdigest()
+        md5sum = hashlib.md5(open(args.model_spec, 'rb').read()).hexdigest()
         pkg_version = ska_helpers.get_version("{}_check".format(self.name))
         mylog.info('##############################'
                    '#######################################')

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -191,13 +191,16 @@ class SQLStateBuilder(StateBuilder):
         states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
                                         state_keys=STATE_KEYS,
                                         merge_identical=False)
+
+        # Need this to generate states.dat output that is consistent with regression
+        # output as of version 3.0.0. Not really used for anything.
         trans_keys_list = []
         for state in states:
             trans_keys = sorted(key for key in state['trans_keys'] if key in STATE_KEYS)
             trans_keys_list.append(','.join(trans_keys))
         states['trans_keys'] = trans_keys_list
-        states = states[sorted(states.colnames)]
 
+        states = states[sorted(states.colnames)]
         state0 = {key: states[0][key] for key in states.colnames}
 
         return states, state0

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-import Ska.DBI
 from Chandra.Time import DateTime
 from pprint import pformat
 import kadi.commands
@@ -8,6 +7,8 @@ import kadi.commands.states as kadi_states
 import logging
 from Ska.File import get_globfiles
 
+# Define state keys for states, corresponding to the legacy states in
+# Chandra.cmd_states.
 STATE_KEYS = ['ccd_count', 'clocking', 'dec', 'dither',
               'fep_count', 'hetg', 'letg', 'obsid', 'pcad_mode', 'pitch',
               'power_cmd', 'q1', 'q2', 'q3', 'q4', 'ra', 'roll', 'si_mode',
@@ -244,10 +245,9 @@ class ACISStateBuilder(StateBuilder):
         # capture the backstop file name and the commands within the backstop file.
         if backstop_file is not None:
             # Get tstart, tstop, commands from backstop file in args.oflsdir
-            # These are the REVIEW backstop commands.
-            # NOTE: This method takes every command. it does not eliminate
-            # commands that are not of interest as sot/cmd_states/get_cmds does.
-            rev_bs_cmds,  self.rev_bs_name = self.BSC.get_bs_cmds(self.backstop_file)
+            # These are the REVIEW backstop commands. This returns a list of dict
+            # representing the commands.
+            rev_bs_cmds, self.rev_bs_name = self.BSC.get_bs_cmds(self.backstop_file)
 
             # Store the Review Load backstop commands in the class attribute and
             # also capture the Review load time of first command (TOFC) and
@@ -301,6 +301,7 @@ class ACISStateBuilder(StateBuilder):
 
         import copy
 
+        # List of dict representing commands at this point
         bs_cmds = copy.copy(self.bs_cmds)
         bs_start_time = bs_cmds[0]['time']
         present_ofls_dir = copy.copy(self.backstop_file)
@@ -309,14 +310,6 @@ class ACISStateBuilder(StateBuilder):
         # time, keep concatenating continuity commands to bs_cmds based upon
         # the type of load.
         # Note that as you march back in time along the load chain, "ofls_dir" will change.
-
-        # First we need a State0 because cmd_states.get_states cannot translate
-        # backstop commands into commanded states without one. cmd_states.get_state0
-        # is written such that if you don't give it a database object it will
-        # create one for itself and use that. Here, all that really matters
-        # is the value of 'tbegin', the specification of the date parameter to be used
-        # and the date_margin.
-        state0 = kadi_states.get_continuity(tbegin)
 
         # WHILE
         # The big while loop that backchains through previous loads and concatenates the
@@ -388,24 +381,34 @@ class ACISStateBuilder(StateBuilder):
                 vo_bs_cmds, vo_bs_name = self.BSC.get_vehicle_only_bs_cmds(cont_load_path)
 
                 # Combine107 the continuity commands with the bs_cmds
-                bs_cmds = self.BSC.Combine107(cont_bs_cmds, vo_bs_cmds, bs_cmds, scs107_date )
+                bs_cmds = self.BSC.Combine107(cont_bs_cmds, vo_bs_cmds, bs_cmds, scs107_date)
 
                 # Reset the backstop collection start time for the While loop
                 bs_start_time = bs_cmds[0]['time']
                 # Now point the operative ofls directory to the Continuity directory
                 present_ofls_dir = cont_load_path
 
-        # Convert the assembled backstop command history into commanded states
-        # from state0 through the end of the Review Load backstop commands.
-        # get_states trims the list to any command whose time is AFTER the state0 START
-        # time and then converts each relevant backstop command, in that resultant list,
-        # into a pseudo-commanded states state
-        states = kadi_states.get_states(continuity=state0,
-                                        cmds=kadi.commands.CommandTable(bs_cmds))
+        # Convert from a list of dict to a CommandTable and store in the object
+        bs_cmds = kadi.commands.CommandTable(bs_cmds)
+        self.bs_cmds = bs_cmds
 
-        # Get rid of the 2099 placeholder stop date
-        states[-1].datestop = bs_cmds[-1]['date']
-        states[-1].tstop = bs_cmds[-1]['time']
+        # Clip commands to tbegin
+        bs_cmds = bs_cmds[bs_cmds['date'] > tbegin]
+
+        # Scheduled stop time is the end of propagation, either the explicit
+        # time as a pseudo-command in the loads or the last backstop command time.
+        # Use the last such command if any are found.
+        ok = bs_cmds['event_type'] == 'SCHEDULED_STOP_TIME'
+        sched_stop = bs_cmds['date'][ok][-1] if np.any(ok) else bs_cmds['date'][-1]
+
+        # Convert the assembled command history into commanded states
+        # corresponding to the commands. This includes continuity commanding
+        # from the end of telemetry along with the in-review load backstop
+        # commands.
+        states = kadi_states.get_states(cmds=bs_cmds, start=tbegin, stop=sched_stop,
+                                        state_keys=STATE_KEYS)
+        states = states[sorted(states.colnames)]
+        state0 = {key: states[0][key] for key in states.colnames}
 
         self.logger.debug('state0 at %s is\n%s' % (DateTime(state0['tstart']).date,
                                                    pformat(state0)))

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -264,13 +264,6 @@ class ACISStateBuilder(StateBuilder):
             self.tstart = rev_bs_cmds[0]['time']
             self.tstop = rev_bs_cmds[-1]['time']
 
-        # Connect to database (NEED TO USE aca_read for sybase; user is ignored for sqlite)
-        # We only need this as the quick way to get the validation states.
-        server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
-        self.logger.info('Connecting to {} to get cmd_states'.format(server))
-        self.db = Ska.DBI.DBI(dbi="sqlite", server=server, user='aca_read',
-                              database='aca')
-
     def get_prediction_states(self, tbegin):
         """
         Get the states used for the prediction.  This includes both the
@@ -331,12 +324,12 @@ class ACISStateBuilder(StateBuilder):
         # create one for itself and use that. Here, all that really matters
         # is the value of 'tbegin', the specification of the date parameter to be used
         # and the date_margin.
-        state0 = cmd_states.get_state0(tbegin, self.db, datepar='datestart',
-                                       date_margin=None)
+        state0 = kadi_states.get_continuity(tbegin)
+
         # WHILE
         # The big while loop that backchains through previous loads and concatenates the
         # proper load sections to the review load.
-        while state0['tstart'] < bs_start_time:
+        while tbegin < bs_start_time:
 
             # Read the Continuity information of the present ofls directory
             cont_load_path, present_load_type, scs107_date = self.BSC.get_continuity_file_info(present_ofls_dir)

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -192,14 +192,6 @@ class SQLStateBuilder(StateBuilder):
                                         state_keys=STATE_KEYS,
                                         merge_identical=False)
 
-        # Need this to generate states.dat output that is consistent with regression
-        # output as of version 3.0.0. Not really used for anything.
-        trans_keys_list = []
-        for state in states:
-            trans_keys = sorted(key for key in state['trans_keys'] if key in STATE_KEYS)
-            trans_keys_list.append(','.join(trans_keys))
-        states['trans_keys'] = trans_keys_list
-
         states = states[sorted(states.colnames)]
         state0 = {key: states[0][key] for key in states.colnames}
 
@@ -329,7 +321,7 @@ class ACISStateBuilder(StateBuilder):
         # WHILE
         # The big while loop that backchains through previous loads and concatenates the
         # proper load sections to the review load.
-        while tbegin < bs_start_time:
+        while DateTime(tbegin).secs < bs_start_time:
 
             # Read the Continuity information of the present ofls directory
             cont_load_path, present_load_type, scs107_date = self.BSC.get_continuity_file_info(present_ofls_dir)
@@ -408,7 +400,8 @@ class ACISStateBuilder(StateBuilder):
         # get_states trims the list to any command whose time is AFTER the state0 START
         # time and then converts each relevant backstop command, in that resultant list,
         # into a pseudo-commanded states state
-        states = cmd_states.get_states(state0, bs_cmds)
+        states = kadi_states.get_states(continuity=state0,
+                                        cmds=kadi.commands.CommandTable(bs_cmds))
 
         # Get rid of the 2099 placeholder stop date
         states[-1].datestop = bs_cmds[-1]['date']

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -127,7 +127,7 @@ class SQLStateBuilder(StateBuilder):
         # 2020) where there is no RLTT and the first command is AOACRSTD. This
         # indicates the beginning of a maneuver ATS which may overlap by 3 mins
         # with the previous loads because of the AOACRSTD command. So to get
-        # continuity right just drop that command.
+        # continuity right just drop that one command.
         if (bs_cmds[0]['tlmsid'] == 'AOACRSTD'
                 and 'RUNNING_LOAD_TERMINATION_TIME' not in bs_cmds['event_type']):
             bs_cmds = bs_cmds[1:]
@@ -148,28 +148,16 @@ class SQLStateBuilder(StateBuilder):
             The starting date/time from which to obtain states for
             prediction.
         """
-
-        """
-        Get state0 as last cmd_state that starts within available telemetry.
-        The original logic in get_state0() is to return a state that
-        is absolutely, positively reliable by insisting that the
-        returned state is at least ``date_margin`` days old, where the
-        default is 10 days. That is too conservative (given the way
-        commanded states are actually managed) and not what is desired
-        here, which is a recent state from which to start thermal propagation.
-
-        Instead we supply ``date_margin=None`` so that get_state0 will
-        find the newest state consistent with the ``date`` criterion
-        and pcad_mode == 'NPNT'.
-        """
+        # This is a kadi.commands.CommandTable (subclass of astropy Table)
         bs_cmds = self.bs_cmds
         bs_dates = bs_cmds['date']
 
-        # Running loads termination time is the last time of "current running loads"
-        # (or in the case of a safing action, "current approved load commands" in
-        # kadi commands) which should be included in propagation. Starting from
-        # around 2020-April this is included as a commmand in the loads, while prior
-        # to that we just use the first command in the backstop loads.
+        # Running loads termination time is the last time of "current running
+        # loads" (or in the case of a safing action, "current approved load
+        # commands" in kadi commands) which should be included in propagation.
+        # Starting from around 2020-April (backstop 6.9) this is included as a
+        # commmand in the loads, while prior to that we just use the first
+        # command in the backstop loads.
         ok = bs_cmds['event_type'] == 'RUNNING_LOAD_TERMINATION_TIME'
         rltt = DateTime(bs_dates[ok][0] if np.any(ok) else bs_dates[0])
 
@@ -188,12 +176,17 @@ class SQLStateBuilder(StateBuilder):
         # Add in the backstop commands
         cmds = cmds.add_cmds(bs_cmds)
 
-        # Get the continuity (state0) and states for available commands.
+        # Get the states for available commands, boxed by tbegin / sched_stop.
+        # The merge_identical=False is for compatibility with legacy Chandra.cmd_states,
+        # but this could probably be set to True.
         states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
                                         state_keys=STATE_KEYS,
                                         merge_identical=False)
 
+        # Make the column order match legacy Chandra.cmd_states.
         states = states[sorted(states.colnames)]
+
+        # Get the first state as a dict.
         state0 = {key: states[0][key] for key in states.colnames}
 
         return states, state0
@@ -208,8 +201,8 @@ class ACISStateBuilder(StateBuilder):
                  logger=None):
         """
         Give the ACISStateBuilder arguments that were passed in
-        from the command line, and set up the connection to the
-        commanded states database.
+        from the command line and get the backstop commands from the load
+        under review.
 
         Parameters
         ----------
@@ -264,7 +257,7 @@ class ACISStateBuilder(StateBuilder):
         of that review load backstop file.
 
         The Review Backstop commands already obtained.
-        Telemtry from 21 days back to  the latest in Ska obtained.
+        Telemtry from 21 days back to the latest in Ska obtained.
 
         So now the task is to backchain through the loads and assemble
         any states missing between the end of telemetry through the start
@@ -275,21 +268,8 @@ class ACISStateBuilder(StateBuilder):
         tbegin : string
             The starting date/time from which to obtain states for
             prediction. This is tlm['date'][-5]) or, in other words, the
-            date used is 5 enteries back from the end of the fetched telemetry
-        """
-
-        """
-        Get state0 as last cmd_state that starts within available telemetry.
-        The original logic in get_state0() is to return a state that
-        is absolutely, positively reliable by insisting that the
-        returned state is at least ``date_margin`` days old, where the
-        default is 10 days. That is too conservative (given the way
-        commanded states are actually managed) and not what is desired
-        here, which is a recent state from which to start thermal propagation.
-
-        Instead we supply ``date_margin=None`` so that get_state0 will
-        find the newest state consistent with the ``date`` criterion
-        and pcad_mode == 'NPNT'.
+            date used is approximately 30 minutes before the end of the
+            fetched telemetry
         """
         # If an OFLS directory has been specified, get the backstop commands
         # stored in the backstop file in that directory
@@ -306,10 +286,10 @@ class ACISStateBuilder(StateBuilder):
         bs_start_time = bs_cmds[0]['time']
         present_ofls_dir = copy.copy(self.backstop_file)
 
-        # So long as the earliest command in bs_cmds is after the state0
-        # time, keep concatenating continuity commands to bs_cmds based upon
-        # the type of load.
-        # Note that as you march back in time along the load chain, "ofls_dir" will change.
+        # So long as the earliest command in bs_cmds is after the state0 time
+        # (which is the same as tbegin), keep concatenating continuity commands
+        # to bs_cmds based upon the type of load. Note that as you march back in
+        # time along the load chain, "ofls_dir" will change.
 
         # WHILE
         # The big while loop that backchains through previous loads and concatenates the
@@ -388,7 +368,8 @@ class ACISStateBuilder(StateBuilder):
                 # Now point the operative ofls directory to the Continuity directory
                 present_ofls_dir = cont_load_path
 
-        # Convert from a list of dict to a CommandTable and store in the object
+        # Convert backstop commands from a list of dict to a CommandTable and
+        # store in self.
         bs_cmds = kadi.commands.CommandTable(bs_cmds)
         self.bs_cmds = bs_cmds
 
@@ -397,7 +378,8 @@ class ACISStateBuilder(StateBuilder):
 
         # Scheduled stop time is the end of propagation, either the explicit
         # time as a pseudo-command in the loads or the last backstop command time.
-        # Use the last such command if any are found.
+        # Use the last such command if any are found (which is always the case
+        # since backstop 6.9).
         ok = bs_cmds['event_type'] == 'SCHEDULED_STOP_TIME'
         sched_stop = bs_cmds['date'][ok][-1] if np.any(ok) else bs_cmds['date'][-1]
 
@@ -407,7 +389,11 @@ class ACISStateBuilder(StateBuilder):
         # commands.
         states = kadi_states.get_states(cmds=bs_cmds, start=tbegin, stop=sched_stop,
                                         state_keys=STATE_KEYS)
+
+        # Make the column order match legacy Chandra.cmd_states.
         states = states[sorted(states.colnames)]
+
+        # Get the first state as a dict.
         state0 = {key: states[0][key] for key in states.colnames}
 
         self.logger.debug('state0 at %s is\n%s' % (DateTime(state0['tstart']).date,

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -1,10 +1,18 @@
 import os
+import numpy as np
 import Ska.DBI
 from Chandra.Time import DateTime
 from pprint import pformat
-import Chandra.cmd_states as cmd_states
+import kadi.commands
+import kadi.commands.states as kadi_states
 import logging
 from Ska.File import get_globfiles
+
+STATE_KEYS = ['ccd_count', 'clocking', 'dec', 'dither',
+              'fep_count', 'hetg', 'letg', 'obsid', 'pcad_mode', 'pitch',
+              'power_cmd', 'q1', 'q2', 'q3', 'q4', 'ra', 'roll', 'si_mode',
+              'simfa_pos', 'simpos',
+              'vid_board']
 
 
 class StateBuilder(object):
@@ -31,20 +39,31 @@ class StateBuilder(object):
 
     def _get_bs_cmds(self):
         """
-        Internal method used to obtain commands from the backstop 
+        Internal method used to obtain commands from the backstop
         file and store them.
         """
-        import Ska.ParseCM
         if os.path.isdir(self.backstop_file):
             # Returns a list but requires exactly 1 match
             backstop_file = get_globfiles(os.path.join(self.backstop_file,
                                                        'CR*.backstop'))[0]
-        else:
-            backstop_file = self.backstop_file
-        self.logger.info('Using backstop file %s' % backstop_file)
-        bs_cmds = Ska.ParseCM.read_backstop(backstop_file)
-        self.logger.info('Found %d backstop commands between %s and %s' %
-                         (len(bs_cmds), bs_cmds[0]['date'], bs_cmds[-1]['date']))
+            self.backstop_file = backstop_file
+
+        self.logger.info('Using backstop file %s' % self.backstop_file)
+
+        # Read the backstop commands and add a `time` column
+        bs_cmds = kadi.commands.get_cmds_from_backstop(backstop_file)
+
+        # Handle the special case of old loads (prior to backstop 6.9 in April
+        # 2020) where there is no RLTT and the first command is AOACRSTD. This
+        # indicates the beginning of a maneuver ATS which may overlap by 3 mins
+        # with the previous loads because of the AOACRSTD command. So to get
+        # continuity right just drop that command.
+        if (bs_cmds[0]['tlmsid'] == 'AOACRSTD'
+                and 'RUNNING_LOAD_TERMINATION_TIME' not in bs_cmds['event_type']):
+            bs_cmds = bs_cmds[1:]
+
+        bs_cmds['time'] = DateTime(bs_cmds['date']).secs
+
         self.bs_cmds = bs_cmds
         self.tstart = bs_cmds[0]['time']
         self.tstop = bs_cmds[-1]['time']
@@ -60,44 +79,42 @@ class StateBuilder(object):
         datestop : string
             The end date to grab states before.
         """
-        datestart = DateTime(datestart).date
-        datestop = DateTime(datestop).date
+        start = DateTime(datestart)
+        stop = DateTime(datestop)
         self.logger.info('Getting commanded states between %s - %s' %
-                         (datestart, datestop))
+                         (start.date, stop.date))
 
-        # Get all states that intersect specified date range
-        cmd = """SELECT * FROM cmd_states
-                 WHERE datestop > '%s' AND datestart < '%s'
-                 ORDER BY datestart""" % (datestart, datestop)
-        self.logger.debug('Query command: %s' % cmd)
-        states = self.db.fetchall(cmd)
-        self.logger.info('Found %d commanded states' % len(states))
+        states = kadi_states.get_states(start, stop, state_keys=STATE_KEYS,
+                                        merge_identical=True)
 
         # Set start and end state date/times to match telemetry span.  Extend the
         # state durations by a small amount because of a precision issue converting
         # to date and back to secs.  (The reference tstop could be just over the
         # 0.001 precision of date and thus cause an out-of-bounds error when
         # interpolating state values).
-        states[0].tstart = DateTime(datestart).secs - 0.01
-        states[0].datestart = DateTime(states[0].tstart).date
-        states[-1].tstop = DateTime(datestop).secs + 0.01
-        states[-1].datestop = DateTime(states[-1].tstop).date
+        dt = 0.01 / 86400
+        states['tstart'][0] = (start - dt).secs
+        states['datestart'][0] = (start - dt).date
+        states['tstop'][-1] = (stop + dt).secs
+        states['datestop'][-1] = (stop + dt).date
 
         return states
 
 
 class SQLStateBuilder(StateBuilder):
     """
-    The SQLStateBuilder contains the original code used to 
+    The SQLStateBuilder contains the original code used to
     obtain commanded states for prediction and validation of
     a thermal model for a particular command load. It can also
     be used for validation only.
+
+    SQL is no longer relevant as the commands and states come from kadi.
     """
-    def __init__(self, interrupt=False, backstop_file=None, 
+    def __init__(self, interrupt=False, backstop_file=None,
                  logger=None):
         """
-        Give the SQLStateBuilder arguments that were passed in 
-        from the command line, and set up the connection to the 
+        Give the SQLStateBuilder arguments that were passed in
+        from the command line, and set up the connection to the
         commanded states database.
 
         Parameters
@@ -105,24 +122,20 @@ class SQLStateBuilder(StateBuilder):
         interrupt : boolean
             If True, this is an interrupt load.
         backstop_file : string
-            Path to the backstop file. If a directory, the backstop 
+            Path to the backstop file. If a directory, the backstop
             file will be searched for within this directory.
         logger : Logger object, optional
             The Python Logger object to be used when logging.
         """
         super(SQLStateBuilder, self).__init__(logger=logger)
+
+        # Note: `interrupt` is ignored in this class. This concept is not needed
+        # since backstop 6.9, which provides the RUNNING_LOAD_TERMINATION_TIME
+        # (RLTT) that can be reliably used to remove scheduled commands that
+        # will not be run.
         self.interrupt = interrupt
         self.backstop_file = backstop_file
-        # Connect to database 
-        server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
-        self.logger.info('Connecting to {} to get cmd_states'.format(server))
-        self.db = Ska.DBI.DBI(dbi="sqlite", server=server, user='aca_read',
-                              database='aca')
-        if self.backstop_file is not None:
-            self._get_bs_cmds()
-#
-# REMOVED _get_bs_cmds call from this location (01/19/2018)
-# Moved the method to the Base class.
+        self._get_bs_cmds()
 
     def get_prediction_states(self, tbegin):
         """
@@ -136,7 +149,7 @@ class SQLStateBuilder(StateBuilder):
         """
 
         """
-        Get state0 as last cmd_state that starts within available telemetry. 
+        Get state0 as last cmd_state that starts within available telemetry.
         The original logic in get_state0() is to return a state that
         is absolutely, positively reliable by insisting that the
         returned state is at least ``date_margin`` days old, where the
@@ -148,81 +161,66 @@ class SQLStateBuilder(StateBuilder):
         find the newest state consistent with the ``date`` criterion
         and pcad_mode == 'NPNT'.
         """
+        bs_cmds = self.bs_cmds
+        bs_dates = bs_cmds['date']
 
-        state0 = cmd_states.get_state0(tbegin, self.db, datepar='datestart',
-                                       date_margin=None)
+        # Running loads termination time is the last time of "current running loads"
+        # (or in the case of a safing action, "current approved load commands" in
+        # kadi commands) which should be included in propagation. Starting from
+        # around 2020-April this is included as a commmand in the loads, while prior
+        # to that we just use the first command in the backstop loads.
+        ok = bs_cmds['event_type'] == 'RUNNING_LOAD_TERMINATION_TIME'
+        rltt = DateTime(bs_dates[ok][0] if np.any(ok) else bs_dates[0])
 
-        self.logger.debug('state0 at %s is\n%s' % (DateTime(state0['tstart']).date,
-                                                   pformat(state0)))
+        # Scheduled stop time is the end of propagation, either the explicit
+        # time as a pseudo-command in the loads or the last backstop command time.
+        ok = bs_cmds['event_type'] == 'SCHEDULED_STOP_TIME'
+        sched_stop = DateTime(bs_dates[ok][0] if np.any(ok) else bs_dates[-1])
 
-        # Get commands after end of state0 through first backstop command time
-        cmds_datestart = state0['datestop']
-        cmds_datestop = self.bs_cmds[0]['date']
+        self.logger.info(f'RLTT = {rltt.date}')
+        self.logger.info(f'sched_stop = {sched_stop.date}')
 
-        # Get timeline load segments including state0 and beyond.
-        timeline_loads = self.db.fetchall("""SELECT * from timeline_loads
-                                          WHERE datestop >= '%s'
-                                          and datestart < '%s'"""
-                                          % (cmds_datestart, cmds_datestop))
-        self.logger.info('Found {} timeline_loads  after {}'.format(
-                         len(timeline_loads), cmds_datestart))
+        # Get currently running (or approved) commands from tbegin up to and
+        # including commands at RLTT
+        cmds = kadi.commands.get_cmds(tbegin, rltt, inclusive_stop=True)
 
-        # Get cmds since datestart within timeline_loads
-        db_cmds = cmd_states.get_cmds(cmds_datestart, db=self.db, update_db=False,
-                                      timeline_loads=timeline_loads)
+        # Add in the backstop commands
+        cmds = cmds.add_cmds(bs_cmds)
 
-        # Delete non-load cmds that are within the backstop time span
-        # => Keep if timeline_id is not None (if a normal load)
-        # or date < bs_cmds[0]['time']
+        # Get the continuity (state0) and states for available commands.
+        states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
+                                        state_keys=STATE_KEYS,
+                                        merge_identical=False)
+        trans_keys_list = []
+        for state in states:
+            trans_keys = sorted(key for key in state['trans_keys'] if key in STATE_KEYS)
+            trans_keys_list.append(','.join(trans_keys))
+        states['trans_keys'] = trans_keys_list
+        states = states[sorted(states.colnames)]
 
-        # If this is an interrupt load, we don't want to include the end 
-        # commands from the continuity load since not all of them will be valid,
-        # and we could end up evolving on states which would not be present in 
-        # the load under review. However, once the load has been approved and is
-        # running / has run on the spacecraft, the states in the database will 
-        # be correct, and we will want to include all relevant commands from the
-        # continuity load. To check for this, we find the current time and see 
-        # the load under review is still in the future. If it is, we then treat
-        # this as an interrupt if requested, otherwise, we don't. 
-        current_time = DateTime().secs
-        interrupt = self.interrupt and self.bs_cmds[0]["time"] > current_time
-
-        db_cmds = [x for x in db_cmds
-                   if ((x['timeline_id'] is not None and not interrupt) or
-                       x['time'] < self.bs_cmds[0]['time'])]
-
-        self.logger.info('Got %d cmds from database between %s and %s' %
-                         (len(db_cmds), cmds_datestart, cmds_datestop))
-
-        # Get the commanded states from state0 through the end of backstop commands
-        states = cmd_states.get_states(state0, db_cmds + self.bs_cmds)
-        states[-1].datestop = self.bs_cmds[-1]['date']
-        states[-1].tstop = self.bs_cmds[-1]['time']
-        self.logger.info('Found %d commanded states from %s to %s' %
-                         (len(states), states[0]['datestart'], 
-                          states[-1]['datestop']))
+        state0 = {key: states[0][key] for key in states.colnames}
 
         return states, state0
 
 
 #-------------------------------------------------------------------------------
-# ACIS Ops Load History assembly 
+# ACIS Ops Load History assembly
 #-------------------------------------------------------------------------------
 class ACISStateBuilder(StateBuilder):
 
-    def __init__(self, interrupt=False, backstop_file=None, nlet_file=None, 
+    def __init__(self, interrupt=False, backstop_file=None, nlet_file=None,
                  logger=None):
         """
-        Give the ACISStateBuilder arguments that were passed in 
-        from the command line, and set up the connection to the 
-        commanded states database. 
+        Give the ACISStateBuilder arguments that were passed in
+        from the command line, and set up the connection to the
+        commanded states database.
 
         Parameters
         ----------
         interrupt : boolean
             If True, this is an interrupt load.
         backstop_file : string
-            Path to the backstop file. If a directory, the backstop 
+            Path to the backstop file. If a directory, the backstop
             file will be searched for within this directory.
         nlet_file : string
             full path to the Non-Load Event Tracking file
@@ -273,8 +271,8 @@ class ACISStateBuilder(StateBuilder):
     def get_prediction_states(self, tbegin):
         """
         Get the states used for the prediction.  This includes both the
-        states from the review load backstop file and all the 
-        states between the latest telemetry data and the beginning 
+        states from the review load backstop file and all the
+        states between the latest telemetry data and the beginning
         of that review load backstop file.
 
         The Review Backstop commands already obtained.
@@ -293,7 +291,7 @@ class ACISStateBuilder(StateBuilder):
         """
 
         """
-        Get state0 as last cmd_state that starts within available telemetry. 
+        Get state0 as last cmd_state that starts within available telemetry.
         The original logic in get_state0() is to return a state that
         is absolutely, positively reliable by insisting that the
         returned state is at least ``date_margin`` days old, where the
@@ -310,7 +308,7 @@ class ACISStateBuilder(StateBuilder):
 
         # Ok ready to start the collection of continuity commands
         #
-        # Make a copy of the Review Load Commands. This will have 
+        # Make a copy of the Review Load Commands. This will have
         # Continuity commands concatenated to it and will be the final product
 
         import copy
@@ -326,8 +324,8 @@ class ACISStateBuilder(StateBuilder):
 
         # First we need a State0 because cmd_states.get_states cannot translate
         # backstop commands into commanded states without one. cmd_states.get_state0
-        # is written such that if you don't give it a database object it will 
-        # create one for itself and use that. Here, all that really matters 
+        # is written such that if you don't give it a database object it will
+        # create one for itself and use that. Here, all that really matters
         # is the value of 'tbegin', the specification of the date parameter to be used
         # and the date_margin.
         state0 = cmd_states.get_state0(tbegin, self.db, datepar='datestart',


### PR DESCRIPTION
## Description

This makes necessary changes to migrate from using `Chandra.cmd_states` and `Ska.ParseCM` to just using `kadi.commands` and `kadi.commands.states`.

This is a WIP and requires the ska3 "shiny" distribution (https://github.com/sot/skare3/wiki/Shiny-Ska3).  At this moment the shiny distribution is not available for installation and testing, so this PR is just to let ACIS know I'm working on this. After taking a look at the original code I realized that it would probably be a tough job for someone else to do this migration, and in fact I ended up making a number of substantive changes to kadi to support this.

Of course this will need comprehensive testing which is best done by ACIS.

Apologies for all the whitespace changes. VS code just does this for me (extraneous whitespace not allowed by astropy), but it is easy enough to change the GitHub diff settings to ignore whitespace (there is a settings button on the file diffs page, google if you can't find it).

This is paired with a PR on `backstop_history`, to be submitted shortly.

In addition, this fixes what appears to be bug in calculating the MD5 sum for a thermal model spec. It seems to be computing the MD5 sum on the file name string, not the file contents.

## Testing

- [N/A] Passes unit tests (no unit tests)
- [x] Functional testing (described below)

### Functional testing

This is not intended to be comprehensive but just a check that this PR is on the right track.

#### Using "sql" state builder

On my Mac using the ska3-shiny distribution:
```
ska3-shiny) ➜  acis_thermal_check git:(shiny) dpa_check \                                  
   --outdir=out_shiny_shiny \
   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
   --state-builder=sql \
   --run-start=2019:135:12:00:00
#####################################################################
# dpa_check (version 3.0.0) run at Tue Jun 30 12:19:03 2020 by aldcroft
# acis_thermal_check version = 3.1.1.dev5+g8bdd907
# model_spec file = /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages/dpa_check/dpa_model_spec.json
# model_spec file MD5sum = 014a9257120258350c148489799f7da6
#####################################################################

Command line options:
{'T_init': None,
 'backstop_file': '/Users/aldcroft/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa',
 'days': 21.0,
 'interrupt': False,
 'model_spec': '/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages/dpa_check/dpa_model_spec.json',
 'nlet_file': '/Users/aldcroft/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt',
 'oflsdir': '/Users/aldcroft/ska/data/ska_testr/test_loads/2019/MAY2019/oflsa',
 'outdir': 'out_shiny_shiny',
 'pred_only': False,
 'run_start': '2019:135:12:00:00',
 'state_builder': 'sql',
 'traceback': True,
 'verbose': 1,
 'version': False}

ACISThermalCheck is using the 'sql' state builder.
Fetching telemetry between 2019:114:12:00:00.000 and 2019:135:12:00:00.000
Calculating DPA thermal model
RLTT = 2019:140:01:00:00.000
sched_stop = 2019:146:23:52:35.589
Fetching msid: dp_dpa_power over 2019:135:11:09:34.816 to 2019:147:00:13:42.816
Making temperature prediction plots
Writing plot file out_shiny_shiny/1dpamzt.png
Writing plot file out_shiny_shiny/pow_sim.png
Writing plot file out_shiny_shiny/roll.png
Checking for limit violations
Writing states to out_shiny_shiny/states.dat
Writing temperatures to out_shiny_shiny/temperatures.dat
Getting commanded states between 2019:114:12:02:38.816 - 2019:135:11:58:46.816
Calculating DPA thermal model for validation
Fetching msid: 1dpamzt over 2019:114:11:40:46.816 to 2019:135:12:15:10.816
Fetching msid: dp_dpa_power over 2019:114:11:40:46.816 to 2019:135:12:15:10.816
Making DPA model validation plots and quantile table
Writing plot file out_shiny_shiny/1dpamzt_valid.png
Writing plot file out_shiny_shiny/1dpamzt_valid_hist.png
Writing plot file out_shiny_shiny/pitch_valid.png
Writing plot file out_shiny_shiny/pitch_valid_hist.png
Writing plot file out_shiny_shiny/tscpos_valid.png
Writing plot file out_shiny_shiny/tscpos_valid_hist.png
Writing plot file out_shiny_shiny/roll_valid.png
Writing plot file out_shiny_shiny/roll_valid_hist.png
Writing plot file out_shiny_shiny/ccd_count_valid.png
Writing quantile table out_shiny_shiny/validation_quant.csv
Writing validation data out_shiny_shiny/validation_data.pkl
Checking for validation violations
WARNING: PITCH 1% quantile value of -3.107 exceeds limit of 3.00
WARNING: PITCH 99% quantile value of 4.022 exceeds limit of 3.00
validation warning(s) in output at out_shiny_shiny
Writing report file out_shiny_shiny/index.rst
```
The output states are the same except for the first one.  `kadi` states always start at exactly the requested start time, not the start of the state it found.
```
(ska3-shiny) ➜  acis_thermal_check git:(shiny) diff out_shiny_shiny/states.dat ~/tmp/dpa/out_flight/states.dat 
2c2
< 5     1       2019:135:11:36:54.816   2019:135:12:18:50.816   66.40351472572986       ENAB    5       RETR    RETR    20552 NPNT     94.59   XTZ0000005      0.391128545     -0.739199939    0.237963076     0.493938747     239.01337324562377      175.04386642278533     TE_00458        -536    92904           674307484.00    674310000.00    1
---
> 5     1       2019:135:09:32:10.816   2019:135:12:18:50.816   66.40351472572986       ENAB    5       RETR    RETR    20552 NPNT     94.59   XTZ0000005      0.391128545     -0.739199939    0.237963076     0.493938747     239.01337324562377      175.04386642278533     TE_00458        -536    92904   pitch   674300000.00    674310000.00    1
```
The output predicted temperatures are the exactly the same (when rounded to 0.01 degC) except for a startup transient that I believe related to the flight version starting 2 hours earlier (09:32 instead of 11:36).
![image](https://user-images.githubusercontent.com/348089/86151286-883cc480-bacc-11ea-8d73-ea74d478c90b.png)

#### Using "ACIS" state builder

Run on my Mac.  This uses an `sshfs` mount to see the appropriate files on the HEAD LAN.

```
(ska3-shiny) ➜  acis_thermal_check git:(shiny) dpa_check \                                                    
   --outdir=headout \
   --oflsdir=/Users/aldcroft/kady/ska/data/acis/LoadReviews/2018/MAY2818/oflsa \
   --run-start=2018:142
GET_BS_CMDS - Using backstop file /Users/aldcroft/kady/ska/data/acis/LoadReviews/2018/MAY2818/oflsa/CR147_2306.backstop
GET_BS_CMDS - Found 1230 backstop commands between 2018:147:23:25:00.000 and 2018:154:23:29:21.284
#####################################################################
# dpa_check (version 3.0.0) run at Tue Jun 30 12:25:10 2020 by aldcroft
# acis_thermal_check version = 3.1.1.dev5+g8bdd907
# model_spec file = /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages/dpa_check/dpa_model_spec.json
# model_spec file MD5sum = 014a9257120258350c148489799f7da6
#####################################################################

Command line options:
{'T_init': None,
 'backstop_file': '/Users/aldcroft/kady/ska/data/acis/LoadReviews/2018/MAY2818/oflsa',
 'days': 21.0,
 'interrupt': False,
 'model_spec': '/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages/dpa_check/dpa_model_spec.json',
 'nlet_file': '/data/acis/LoadReviews/NonLoadTrackedEvents.txt',
 'oflsdir': '/Users/aldcroft/kady/ska/data/acis/LoadReviews/2018/MAY2818/oflsa',
 'outdir': 'headout',
 'pred_only': False,
 'run_start': '2018:142',
 'state_builder': 'acis',
 'traceback': True,
 'verbose': 1,
 'version': False}

ACISThermalCheck is using the 'acis' state builder.
Fetching telemetry between 2018:121:12:00:00.000 and 2018:142:12:00:00.000
Calculating DPA thermal model
GET_BS_CMDS - Using backstop file /Users/aldcroft/kady/ska/data/acis/LoadReviews/2018/MAY2118/ofls/CR141_0311.backstop
GET_BS_CMDS - Found 1492 backstop commands between 2018:141:03:35:03.643 and 2018:147:23:27:16.409
Fetching msid: dp_dpa_power over 2018:142:11:11:58.816 to 2018:154:23:46:30.816
Making temperature prediction plots
Writing plot file headout/1dpamzt.png
Writing plot file headout/pow_sim.png
Writing plot file headout/roll.png
Checking for limit violations
Writing states to headout/states.dat
Writing temperatures to headout/temperatures.dat
Getting commanded states between 2018:121:12:05:02.816 - 2018:142:11:55:42.816
Calculating DPA thermal model for validation
Fetching msid: 1dpamzt over 2018:121:11:43:10.816 to 2018:142:12:17:34.816
Fetching msid: dp_dpa_power over 2018:121:11:43:10.816 to 2018:142:12:17:34.816
Making DPA model validation plots and quantile table
Writing plot file headout/1dpamzt_valid.png
Writing plot file headout/1dpamzt_valid_hist.png
Writing plot file headout/pitch_valid.png
Writing plot file headout/pitch_valid_hist.png
Writing plot file headout/tscpos_valid.png
Writing plot file headout/tscpos_valid_hist.png
Writing plot file headout/roll_valid.png
Writing plot file headout/roll_valid_hist.png
Writing plot file headout/ccd_count_valid.png
Writing quantile table headout/validation_quant.csv
Writing validation data headout/validation_data.pkl
Checking for validation violations
WARNING: 1DPAMZT 1% quantile value of -2.81 exceeds limit of 2.00
WARNING: PITCH 1% quantile value of -3.882 exceeds limit of 3.00
WARNING: PITCH 99% quantile value of 3.867 exceeds limit of 3.00
validation warning(s) in output at headout
Writing report file headout/index.rst
```

**The results are similar to the SQL builder diffs:**
- The states are all identical except for the start time of the first state.
- The temperature predictions are identical after about a day from the start, and within 0.3 degC otherwise.