### PR TITLE
Add an extra FP limit at -109 C, change FP SENS limit

### DIFF
--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -768,7 +768,9 @@ class ACISThermalCheck(object):
             if self.msid == msid:
                 ymin, ymax = ax.get_ylim()
                 if msid == "fptemp":
-                    fp_sens, acis_s, acis_i, acis_hot = get_acis_limits("fptemp")
+                    cold_ecs, acis_s, acis_i, acis_hot = get_acis_limits("fptemp")
+                    ax.axhline(cold_ecs, linestyle='-.', color='dodgerblue', 
+                               zorder=-8, linewidth=2)
                     ax.axhline(acis_i, linestyle='-.', color='purple', zorder=-8,
                                linewidth=2)
                     ax.axhline(acis_s, linestyle='-.', color='blue', zorder=-8,

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -768,12 +768,14 @@ class ACISThermalCheck(object):
             if self.msid == msid:
                 ymin, ymax = ax.get_ylim()
                 if msid == "fptemp":
-                    fp_sens, acis_s, acis_i = get_acis_limits("fptemp")
+                    fp_sens, acis_s, acis_i, acis_hot = get_acis_limits("fptemp")
                     ax.axhline(acis_i, linestyle='-.', color='purple', zorder=-8,
                                linewidth=2)
                     ax.axhline(acis_s, linestyle='-.', color='blue', zorder=-8,
                                linewidth=2)
-                    ymax = max(acis_i+1, ymax)
+                    ax.axhline(acis_hot, linestyle='-.', color='red', zorder=-8,
+                               linewidth=2)
+                    ymax = max(acis_hot+1, ymax)
                 else:
                     ax.axhline(self.yellow_hi, linestyle='-', color='gold', 
                                zorder=-8, linewidth=2)

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -182,7 +182,9 @@ def plot_one(fig_id, x, y, yy=None, linestyle='-',
         ax.axvline(load_start, linestyle='-', color='g', linewidth=2.0)
 
     Ska.Matplotlib.set_time_ticks(ax)
-    [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
+    for label in ax.xaxis.get_ticklabels():
+        label.set_rotation(30)
+        label.set_horizontalalignment('left')
 
     fig.subplots_adjust(bottom=0.22, right=0.87)
     # The next several lines ensure that the width of the axes

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -439,7 +439,7 @@ def get_acis_limits(msid):
     import requests
 
     if msid == "fptemp":
-        fp_sens = -119.2
+        fp_sens = -119.5
         acis_i = -112.0
         acis_s = -111.0
         acis_hot = -109.0

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -448,11 +448,11 @@ def get_acis_limits(msid):
     import requests
 
     if msid == "fptemp":
-        fp_sens = -119.5
+        cold_ecs = -119.5
         acis_i = -112.0
         acis_s = -111.0
         acis_hot = -109.0
-        return fp_sens, acis_i, acis_s, acis_hot
+        return cold_ecs, acis_i, acis_s, acis_hot
 
     yellow_lo = None
     yellow_hi = None

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -439,10 +439,11 @@ def get_acis_limits(msid):
     import requests
 
     if msid == "fptemp":
-        fp_sens = -118.7
+        fp_sens = -119.2
         acis_i = -112.0
         acis_s = -111.0
-        return fp_sens, acis_i, acis_s
+        acis_hot = -109.0
+        return fp_sens, acis_i, acis_s, acis_hot
 
     yellow_lo = None
     yellow_hi = None

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -448,10 +448,10 @@ def get_acis_limits(msid):
     import requests
 
     if msid == "fptemp":
-        cold_ecs = -119.5
-        acis_i = -112.0
-        acis_s = -111.0
-        acis_hot = -109.0
+        cold_ecs = -119.5 # the limit for cold ECS measurements in the science orbit
+        acis_i = -112.0 # the limit for ACIS-I observations
+        acis_s = -111.0 # the limit for normal ACIS-S observations
+        acis_hot = -109.0 # the limit for ACIS-S observations which can go hotter
         return cold_ecs, acis_i, acis_s, acis_hot
 
     yellow_lo = None

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -183,8 +183,11 @@ def plot_one(fig_id, x, y, yy=None, linestyle='-',
 
     Ska.Matplotlib.set_time_ticks(ax)
     for label in ax.xaxis.get_ticklabels():
+        label.set_rotation_mode("anchor")
         label.set_rotation(30)
-        label.set_horizontalalignment('left')
+        label.set_horizontalalignment('right')
+    ax.tick_params(which='major', axis='x', length=6)
+    ax.tick_params(which='minor', axis='x', length=3)
 
     fig.subplots_adjust(bottom=0.22, right=0.87)
     # The next several lines ensure that the width of the axes
@@ -296,9 +299,13 @@ def plot_two(fig_id, x, y, x2, y2, yy=None, linewidth=2,
         ax.axvline(load_start, linestyle='-', color='g', linewidth=2.0)
 
     Ska.Matplotlib.set_time_ticks(ax)
-    [label.set_rotation(30) for label in ax.xaxis.get_ticklabels()]
+    for label in ax.xaxis.get_ticklabels():
+        label.set_rotation_mode("anchor")
+        label.set_rotation(30)
+        label.set_horizontalalignment('right')
     [label.set_color(color2) for label in ax2.yaxis.get_ticklabels()]
-
+    ax.tick_params(which='major', axis='x', length=6)
+    ax.tick_params(which='minor', axis='x', length=3)
     fig.subplots_adjust(bottom=0.22, right=0.87)
     # The next several lines ensure that the width of the axes
     # of all the weekly prediction plots are the same


### PR DESCRIPTION
## Description

This PR does three things:

* In anticipation of ACIS-S observations which go to -109 C, an extra limit is added for the focal plane temperature and plots an extra line on validation plots at -109 C.
* The "FP SENS" limit is changed from -118.7 C to -119.5 C. This limit will be used to catch violations of cold ECS measurements in the science orbit, instead of its older use for FP-sensitive observations.
* x-axis tick labels have been placed so that their end points directly at the tick they correspond to, and the minor and major ticks have had their lengths increased.

Other functionality related to both of these changes is handled in the companion PR https://github.com/acisops/acisfp_check/pull/24.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing