### PR TITLE
Re-issue Shiny PR

### DIFF
--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1026,8 +1026,7 @@ class ACISThermalCheck(object):
         if self.msid != "fptemp":
             proc["msid_limit"] = self.yellow_hi - self.margin
         # Figure out the MD5 sum of model spec file
-        model_json = json.dumps(args.model_spec, sort_keys=True, indent=4).encode("utf-8")
-        md5sum = hashlib.md5(model_json).hexdigest()
+        md5sum = hashlib.md5(open(args.model_spec, 'rb').read()).hexdigest()
         pkg_version = ska_helpers.get_version("{}_check".format(self.name))
         mylog.info('##############################'
                    '#######################################')

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -503,7 +503,8 @@ class ACISThermalCheck(object):
         states_table['pitch'].format = '%.2f'
         states_table['tstart'].format = '%.2f'
         states_table['tstop'].format = '%.2f'
-        states_table.write(outfile, format='ascii', delimiter='\t', overwrite=True)
+        states_table.write(outfile, format='ascii', delimiter='\t', overwrite=True,
+                           fast_writer=False)
 
     def write_temps(self, outdir, times, temps):
         """

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -95,28 +95,6 @@ class TestArgs(object):
             self.fps_nopref = os.path.join(model_path, "FPS_NoPref.txt")
 
 
-# Large, multi-layer dictionary which encodes the datatypes for the
-# different quantities that are being checked against.
-data_dtype = {'temperatures': {'names': ('time', 'date', 'temperature'),
-                               'formats': ('f8', 'S21', 'f8')
-                              },
-              'earth_solid_angles': {'names': ('time', 'date', 'earth_solid_angle'),
-                                     'formats': ('f8', 'S21', 'f8')
-                                     },
-              'states': {'names': ('ccd_count', 'clocking', 'datestart',
-                                   'datestop', 'dec', 'dither', 'fep_count',
-                                   'hetg', 'letg', 'obsid', 'pcad_mode',
-                                   'pitch', 'power_cmd', 'q1', 'q2', 'q3',
-                                   'q4', 'ra', 'roll', 'si_mode', 'simfa_pos',
-                                   'simpos', 'trans_keys'),
-                         'formats': ('i4', 'i4', 'S21', 'S21', 'f8', 'S4',
-                                     'i4', 'S4', 'S4', 'i4', 'S4', 'f8',
-                                     'S9', 'f8', 'f8', 'f8', 'f8', 'f8',
-                                     'f8', 'S8', 'i4', 'i4', 'S80')
-                        }
-             }
-
-
 def exception_catcher(test, old, new, data_type, **kwargs):
     if new.dtype.kind == "S":
         new = new.astype("U")
@@ -316,12 +294,12 @@ class RegressionTester(object):
         filenames : list of strings
             The list of files which will be used in the comparison.
         """
+        from astropy.io import ascii
         for fn in filenames:
-            prefix = fn.split(".")[0]
             new_fn = os.path.join(out_dir, fn)
             old_fn = os.path.join(self.model_path, "tests/answers", load_week, fn)
-            new_data = np.loadtxt(new_fn, skiprows=1, dtype=data_dtype[prefix])
-            old_data = np.loadtxt(old_fn, skiprows=1, dtype=data_dtype[prefix])
+            new_data = ascii.read(new_fn).as_array()
+            old_data = ascii.read(old_fn).as_array()
             # Compare test run data to gold standard. Since we're loading from
             # ASCII text files here, floating-point comparisons will be different
             # at machine precision, others will be exact.

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -268,13 +268,6 @@ class ACISStateBuilder(StateBuilder):
             # At the beginning, it will be the time of the last command in the Review Load
             self.BSC.end_event_time = rev_bs_cmds[-1]['time']
 
-        # Connect to database (NEED TO USE aca_read for sybase; user is ignored for sqlite)
-        # We only need this as the quick way to get the validation states.
-        server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
-        self.logger.info('Connecting to {} to get cmd_states'.format(server))
-        self.db = Ska.DBI.DBI(dbi="sqlite", server=server, user='aca_read',
-                              database='aca')
-
     def get_prediction_states(self, tbegin):
         """
         Get the states used for the prediction.  This includes both the
@@ -340,12 +333,12 @@ class ACISStateBuilder(StateBuilder):
         # create one for itself and use that. Here, all that really matters
         # is the value of 'tbegin', the specification of the date parameter to be used
         # and the date_margin.
-        state0 = cmd_states.get_state0(tbegin, self.db, datepar='datestart',
-                                       date_margin=None)
+        state0 = kadi_states.get_continuity(tbegin)
+
         # WHILE
         # The big while loop that backchains through previous loads and concatenates the
         # proper load sections to the review load.
-        while state0['tstart'] < bs_start_time:
+        while tbegin < bs_start_time:
 
             # Read the Continuity information of the present ofls directory
             cont_load_path, present_load_type, scs107_date = self.BSC.get_continuity_file_info(present_ofls_dir)

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -192,14 +192,6 @@ class SQLStateBuilder(StateBuilder):
                                         state_keys=STATE_KEYS,
                                         merge_identical=False)
 
-        # Need this to generate states.dat output that is consistent with regression
-        # output as of version 3.0.0. Not really used for anything.
-        trans_keys_list = []
-        for state in states:
-            trans_keys = sorted(key for key in state['trans_keys'] if key in STATE_KEYS)
-            trans_keys_list.append(','.join(trans_keys))
-        states['trans_keys'] = trans_keys_list
-
         states = states[sorted(states.colnames)]
         state0 = {key: states[0][key] for key in states.colnames}
 
@@ -338,7 +330,7 @@ class ACISStateBuilder(StateBuilder):
         # WHILE
         # The big while loop that backchains through previous loads and concatenates the
         # proper load sections to the review load.
-        while tbegin < bs_start_time:
+        while DateTime(tbegin).secs < bs_start_time:
 
             # Read the Continuity information of the present ofls directory
             cont_load_path, present_load_type, scs107_date = self.BSC.get_continuity_file_info(present_ofls_dir)
@@ -418,7 +410,8 @@ class ACISStateBuilder(StateBuilder):
         # get_states trims the list to any command whose time is AFTER the state0 START
         # time and then converts each relevant backstop command, in that resultant list,
         # into a pseudo-commanded states state
-        states = cmd_states.get_states(state0, bs_cmds)
+        states = kadi_states.get_states(continuity=state0,
+                                        cmds=kadi.commands.CommandTable(bs_cmds))
 
         # Get rid of the 2099 placeholder stop date
         states[-1].datestop = bs_cmds[-1]['date']

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -1,10 +1,18 @@
 import os
+import numpy as np
 import Ska.DBI
 from Chandra.Time import DateTime
 from pprint import pformat
-import Chandra.cmd_states as cmd_states
+import kadi.commands
+import kadi.commands.states as kadi_states
 import logging
 from Ska.File import get_globfiles
+
+STATE_KEYS = ['ccd_count', 'clocking', 'dec', 'dither',
+              'fep_count', 'hetg', 'letg', 'obsid', 'pcad_mode', 'pitch',
+              'power_cmd', 'q1', 'q2', 'q3', 'q4', 'ra', 'roll', 'si_mode',
+              'simfa_pos', 'simpos',
+              'vid_board']
 
 
 class StateBuilder(object):
@@ -31,20 +39,31 @@ class StateBuilder(object):
 
     def _get_bs_cmds(self):
         """
-        Internal method used to obtain commands from the backstop 
+        Internal method used to obtain commands from the backstop
         file and store them.
         """
-        import Ska.ParseCM
         if os.path.isdir(self.backstop_file):
             # Returns a list but requires exactly 1 match
             backstop_file = get_globfiles(os.path.join(self.backstop_file,
                                                        'CR*.backstop'))[0]
-        else:
-            backstop_file = self.backstop_file
-        self.logger.info('Using backstop file %s' % backstop_file)
-        bs_cmds = Ska.ParseCM.read_backstop(backstop_file)
-        self.logger.info('Found %d backstop commands between %s and %s' %
-                         (len(bs_cmds), bs_cmds[0]['date'], bs_cmds[-1]['date']))
+            self.backstop_file = backstop_file
+
+        self.logger.info('Using backstop file %s' % self.backstop_file)
+
+        # Read the backstop commands and add a `time` column
+        bs_cmds = kadi.commands.get_cmds_from_backstop(backstop_file)
+
+        # Handle the special case of old loads (prior to backstop 6.9 in April
+        # 2020) where there is no RLTT and the first command is AOACRSTD. This
+        # indicates the beginning of a maneuver ATS which may overlap by 3 mins
+        # with the previous loads because of the AOACRSTD command. So to get
+        # continuity right just drop that command.
+        if (bs_cmds[0]['tlmsid'] == 'AOACRSTD'
+                and 'RUNNING_LOAD_TERMINATION_TIME' not in bs_cmds['event_type']):
+            bs_cmds = bs_cmds[1:]
+
+        bs_cmds['time'] = DateTime(bs_cmds['date']).secs
+
         self.bs_cmds = bs_cmds
         self.tstart = bs_cmds[0]['time']
         self.tstop = bs_cmds[-1]['time']
@@ -60,44 +79,42 @@ class StateBuilder(object):
         datestop : string
             The end date to grab states before.
         """
-        datestart = DateTime(datestart).date
-        datestop = DateTime(datestop).date
+        start = DateTime(datestart)
+        stop = DateTime(datestop)
         self.logger.info('Getting commanded states between %s - %s' %
-                         (datestart, datestop))
+                         (start.date, stop.date))
 
-        # Get all states that intersect specified date range
-        cmd = """SELECT * FROM cmd_states
-                 WHERE datestop > '%s' AND datestart < '%s'
-                 ORDER BY datestart""" % (datestart, datestop)
-        self.logger.debug('Query command: %s' % cmd)
-        states = self.db.fetchall(cmd)
-        self.logger.info('Found %d commanded states' % len(states))
+        states = kadi_states.get_states(start, stop, state_keys=STATE_KEYS,
+                                        merge_identical=True)
 
         # Set start and end state date/times to match telemetry span.  Extend the
         # state durations by a small amount because of a precision issue converting
         # to date and back to secs.  (The reference tstop could be just over the
         # 0.001 precision of date and thus cause an out-of-bounds error when
         # interpolating state values).
-        states[0].tstart = DateTime(datestart).secs - 0.01
-        states[0].datestart = DateTime(states[0].tstart).date
-        states[-1].tstop = DateTime(datestop).secs + 0.01
-        states[-1].datestop = DateTime(states[-1].tstop).date
+        dt = 0.01 / 86400
+        states['tstart'][0] = (start - dt).secs
+        states['datestart'][0] = (start - dt).date
+        states['tstop'][-1] = (stop + dt).secs
+        states['datestop'][-1] = (stop + dt).date
 
         return states
 
 
 class SQLStateBuilder(StateBuilder):
     """
-    The SQLStateBuilder contains the original code used to 
+    The SQLStateBuilder contains the original code used to
     obtain commanded states for prediction and validation of
     a thermal model for a particular command load. It can also
     be used for validation only.
+
+    SQL is no longer relevant as the commands and states come from kadi.
     """
-    def __init__(self, interrupt=False, backstop_file=None, 
+    def __init__(self, interrupt=False, backstop_file=None,
                  logger=None):
         """
-        Give the SQLStateBuilder arguments that were passed in 
-        from the command line, and set up the connection to the 
+        Give the SQLStateBuilder arguments that were passed in
+        from the command line, and set up the connection to the
         commanded states database.
 
         Parameters
@@ -105,24 +122,20 @@ class SQLStateBuilder(StateBuilder):
         interrupt : boolean
             If True, this is an interrupt load.
         backstop_file : string
-            Path to the backstop file. If a directory, the backstop 
+            Path to the backstop file. If a directory, the backstop
             file will be searched for within this directory.
         logger : Logger object, optional
             The Python Logger object to be used when logging.
         """
         super(SQLStateBuilder, self).__init__(logger=logger)
+
+        # Note: `interrupt` is ignored in this class. This concept is not needed
+        # since backstop 6.9, which provides the RUNNING_LOAD_TERMINATION_TIME
+        # (RLTT) that can be reliably used to remove scheduled commands that
+        # will not be run.
         self.interrupt = interrupt
         self.backstop_file = backstop_file
-        # Connect to database 
-        server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
-        self.logger.info('Connecting to {} to get cmd_states'.format(server))
-        self.db = Ska.DBI.DBI(dbi="sqlite", server=server, user='aca_read',
-                              database='aca')
-        if self.backstop_file is not None:
-            self._get_bs_cmds()
-#
-# REMOVED _get_bs_cmds call from this location (01/19/2018)
-# Moved the method to the Base class.
+        self._get_bs_cmds()
 
     def get_prediction_states(self, tbegin):
         """
@@ -136,7 +149,7 @@ class SQLStateBuilder(StateBuilder):
         """
 
         """
-        Get state0 as last cmd_state that starts within available telemetry. 
+        Get state0 as last cmd_state that starts within available telemetry.
         The original logic in get_state0() is to return a state that
         is absolutely, positively reliable by insisting that the
         returned state is at least ``date_margin`` days old, where the
@@ -148,81 +161,66 @@ class SQLStateBuilder(StateBuilder):
         find the newest state consistent with the ``date`` criterion
         and pcad_mode == 'NPNT'.
         """
+        bs_cmds = self.bs_cmds
+        bs_dates = bs_cmds['date']
 
-        state0 = cmd_states.get_state0(tbegin, self.db, datepar='datestart',
-                                       date_margin=None)
+        # Running loads termination time is the last time of "current running loads"
+        # (or in the case of a safing action, "current approved load commands" in
+        # kadi commands) which should be included in propagation. Starting from
+        # around 2020-April this is included as a commmand in the loads, while prior
+        # to that we just use the first command in the backstop loads.
+        ok = bs_cmds['event_type'] == 'RUNNING_LOAD_TERMINATION_TIME'
+        rltt = DateTime(bs_dates[ok][0] if np.any(ok) else bs_dates[0])
 
-        self.logger.debug('state0 at %s is\n%s' % (DateTime(state0['tstart']).date,
-                                                   pformat(state0)))
+        # Scheduled stop time is the end of propagation, either the explicit
+        # time as a pseudo-command in the loads or the last backstop command time.
+        ok = bs_cmds['event_type'] == 'SCHEDULED_STOP_TIME'
+        sched_stop = DateTime(bs_dates[ok][0] if np.any(ok) else bs_dates[-1])
 
-        # Get commands after end of state0 through first backstop command time
-        cmds_datestart = state0['datestop']
-        cmds_datestop = self.bs_cmds[0]['date']
+        self.logger.info(f'RLTT = {rltt.date}')
+        self.logger.info(f'sched_stop = {sched_stop.date}')
 
-        # Get timeline load segments including state0 and beyond.
-        timeline_loads = self.db.fetchall("""SELECT * from timeline_loads
-                                          WHERE datestop >= '%s'
-                                          and datestart < '%s'"""
-                                          % (cmds_datestart, cmds_datestop))
-        self.logger.info('Found {} timeline_loads  after {}'.format(
-                         len(timeline_loads), cmds_datestart))
+        # Get currently running (or approved) commands from tbegin up to and
+        # including commands at RLTT
+        cmds = kadi.commands.get_cmds(tbegin, rltt, inclusive_stop=True)
 
-        # Get cmds since datestart within timeline_loads
-        db_cmds = cmd_states.get_cmds(cmds_datestart, db=self.db, update_db=False,
-                                      timeline_loads=timeline_loads)
+        # Add in the backstop commands
+        cmds = cmds.add_cmds(bs_cmds)
 
-        # Delete non-load cmds that are within the backstop time span
-        # => Keep if timeline_id is not None (if a normal load)
-        # or date < bs_cmds[0]['time']
+        # Get the continuity (state0) and states for available commands.
+        states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
+                                        state_keys=STATE_KEYS,
+                                        merge_identical=False)
+        trans_keys_list = []
+        for state in states:
+            trans_keys = sorted(key for key in state['trans_keys'] if key in STATE_KEYS)
+            trans_keys_list.append(','.join(trans_keys))
+        states['trans_keys'] = trans_keys_list
+        states = states[sorted(states.colnames)]
 
-        # If this is an interrupt load, we don't want to include the end 
-        # commands from the continuity load since not all of them will be valid,
-        # and we could end up evolving on states which would not be present in 
-        # the load under review. However, once the load has been approved and is
-        # running / has run on the spacecraft, the states in the database will 
-        # be correct, and we will want to include all relevant commands from the
-        # continuity load. To check for this, we find the current time and see 
-        # the load under review is still in the future. If it is, we then treat
-        # this as an interrupt if requested, otherwise, we don't. 
-        current_time = DateTime().secs
-        interrupt = self.interrupt and self.bs_cmds[0]["time"] > current_time
-
-        db_cmds = [x for x in db_cmds
-                   if ((x['timeline_id'] is not None and not interrupt) or
-                       x['time'] < self.bs_cmds[0]['time'])]
-
-        self.logger.info('Got %d cmds from database between %s and %s' %
-                         (len(db_cmds), cmds_datestart, cmds_datestop))
-
-        # Get the commanded states from state0 through the end of backstop commands
-        states = cmd_states.get_states(state0, db_cmds + self.bs_cmds)
-        states[-1].datestop = self.bs_cmds[-1]['date']
-        states[-1].tstop = self.bs_cmds[-1]['time']
-        self.logger.info('Found %d commanded states from %s to %s' %
-                         (len(states), states[0]['datestart'], 
-                          states[-1]['datestop']))
+        state0 = {key: states[0][key] for key in states.colnames}
 
         return states, state0
 
 
 #-------------------------------------------------------------------------------
-# ACIS Ops Load History assembly 
+# ACIS Ops Load History assembly
 #-------------------------------------------------------------------------------
 class ACISStateBuilder(StateBuilder):
 
-    def __init__(self, interrupt=False, backstop_file=None, nlet_file=None, 
+    def __init__(self, interrupt=False, backstop_file=None, nlet_file=None,
                  logger=None):
         """
-        Give the ACISStateBuilder arguments that were passed in 
-        from the command line, and set up the connection to the 
-        commanded states database. 
+        Give the ACISStateBuilder arguments that were passed in
+        from the command line, and set up the connection to the
+        commanded states database.
 
         Parameters
         ----------
         interrupt : boolean
             If True, this is an interrupt load.
         backstop_file : string
-            Path to the backstop file. If a directory, the backstop 
+            Path to the backstop file. If a directory, the backstop
             file will be searched for within this directory.
         nlet_file : string
             full path to the Non-Load Event Tracking file
@@ -277,8 +275,8 @@ class ACISStateBuilder(StateBuilder):
     def get_prediction_states(self, tbegin):
         """
         Get the states used for the prediction.  This includes both the
-        states from the review load backstop file and all the 
-        states between the latest telemetry data and the beginning 
+        states from the review load backstop file and all the
+        states between the latest telemetry data and the beginning
         of that review load backstop file.
 
         The Review Backstop commands already obtained.
@@ -297,7 +295,7 @@ class ACISStateBuilder(StateBuilder):
         """
 
         """
-        Get state0 as last cmd_state that starts within available telemetry. 
+        Get state0 as last cmd_state that starts within available telemetry.
         The original logic in get_state0() is to return a state that
         is absolutely, positively reliable by insisting that the
         returned state is at least ``date_margin`` days old, where the
@@ -314,7 +312,7 @@ class ACISStateBuilder(StateBuilder):
 
         # Ok ready to start the collection of continuity commands
         #
-        # Make a copy of the Review Load Commands. This will have 
+        # Make a copy of the Review Load Commands. This will have
         # Continuity commands concatenated to it and will be the final product
 
         import copy
@@ -335,8 +333,8 @@ class ACISStateBuilder(StateBuilder):
 
         # First we need a State0 because cmd_states.get_states cannot translate
         # backstop commands into commanded states without one. cmd_states.get_state0
-        # is written such that if you don't give it a database object it will 
-        # create one for itself and use that. Here, all that really matters 
+        # is written such that if you don't give it a database object it will
+        # create one for itself and use that. Here, all that really matters
         # is the value of 'tbegin', the specification of the date parameter to be used
         # and the date_margin.
         state0 = cmd_states.get_state0(tbegin, self.db, datepar='datestart',

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -191,13 +191,16 @@ class SQLStateBuilder(StateBuilder):
         states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
                                         state_keys=STATE_KEYS,
                                         merge_identical=False)
+
+        # Need this to generate states.dat output that is consistent with regression
+        # output as of version 3.0.0. Not really used for anything.
         trans_keys_list = []
         for state in states:
             trans_keys = sorted(key for key in state['trans_keys'] if key in STATE_KEYS)
             trans_keys_list.append(','.join(trans_keys))
         states['trans_keys'] = trans_keys_list
-        states = states[sorted(states.colnames)]
 
+        states = states[sorted(states.colnames)]
         state0 = {key: states[0][key] for key in states.colnames}
 
         return states, state0


### PR DESCRIPTION
## Description

This is a re-issue of the Shiny PR #30 after recent updates. This requires https://github.com/acisops/backstop_history/pull/14.

## Testing

- [N/A] Passes unit tests (no unit tests)
- [x] Functional testing (quick tests)
- [ ] Functional testing (ACIS regression testing)

### Functional testing from @taldcroft 

I re-ran these quick functional tests originally documented in #30 

```
(ska3-shiny) ➜  export ALLOW_NONSTANDARD_OFLSDIR=1

(ska3-shiny) ➜  acis_thermal_check git:(shiny) dpa_check \                                  
   --outdir=out_shiny_shiny \
   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
   --state-builder=sql \
   --run-start=2019:135:12:00:00

(ska3-shiny) ➜  acis_thermal_check git:(shiny) dpa_check \                                                    
   --outdir=headout \
   --oflsdir=${SKA}/data/acis/LoadReviews/2018/MAY2818/oflsa \
  --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
  --run-start=2018:142
```
The state diffs were the same as listed in #30.

Then I re-ran these two tests that had shown some issues early in #30 

```
dpa_check --oflsdir ~/ska/data/acis/LoadReviews/2017/MAR0617/oflsa --state-builder=sql \
--out=test_dpa_mar0617a_sql --nlet_file ~/ska/data/acis/LoadReviews/NonLoadTrackedEvents.txt

dpa_check --oflsdir ~/ska/data/acis/LoadReviews/2017/MAR0617/oflsa --state-builder=acis \
--out=test_dpa_mar0617a_acis --nlet_file ~/ska/data/acis/LoadReviews/NonLoadTrackedEvents.txt

diff test_dpa_mar0617a_{sql,acis}/states.dat  # no diffs
```

