### PR TITLE
Refactoring of limit handling, allowing for more customizations, use cxotime

### DIFF
--- a/acis_thermal_check/data/limits.yml
+++ b/acis_thermal_check/data/limits.yml
@@ -1,0 +1,36 @@
+1dpamzt:
+  plan_hi: 37.5
+  yellow_hi: 39.5
+  zero_feps: 12.0
+
+1deamzt:
+  plan_hi: 36.5
+  yellow_hi: 38.5
+
+1pdeaat:
+  plan_hi: 52.5
+  yellow_hi: 56.0
+  
+fptemp:
+  cold_ecs: -119.5
+  acis_s: -111.0
+  acis_i: -112.0
+  acis_hot: -109.0
+ 
+tmp_fep1_actel:
+  plan_hi: 46.0
+  yellow_hi: 48.0
+  plan_lo: 2.0
+  yellow_lo: 0.0
+
+tmp_fep1_mong:
+  plan_hi: 47.0
+  yellow_hi: 49.0
+  plan_lo: 2.0
+  yellow_lo: 0.0
+    
+tmp_bep_pcb:
+  plan_hi: 42.0
+  yellow_hi: 44.0
+  plan_lo: 4.5
+  yellow_lo: 6.5

--- a/acis_thermal_check/data/limits.yml
+++ b/acis_thermal_check/data/limits.yml
@@ -32,5 +32,5 @@ tmp_fep1_mong:
 tmp_bep_pcb:
   plan_hi: 42.0
   yellow_hi: 44.0
-  plan_lo: 4.5
+  plan_lo: 8.5
   yellow_lo: 6.5

--- a/acis_thermal_check/data/limits.yml
+++ b/acis_thermal_check/data/limits.yml
@@ -4,8 +4,8 @@
   zero_feps: 12.0
 
 1deamzt:
-  plan_hi: 36.5
-  yellow_hi: 38.5
+  plan_hi: 37.5
+  yellow_hi: 39.5
 
 1pdeaat:
   plan_hi: 52.5

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -150,9 +150,6 @@ class ACISThermalCheck(object):
                     mylog.warning("Replacing %s %.2f with %.2f" % (k, limit, v))
                     setattr(self, k, v)
 
-        if self.msid != "fptemp":
-            proc["msid_limit"] = self.plan_hi_limit
-
         # Determine the start and stop times either from whatever was
         # stored in state_builder or punt by using NOW and None for
         # tstart and tstop.
@@ -491,7 +488,7 @@ class ACISThermalCheck(object):
                                                self.plan_hi_limit,
                                                "planning", "max")
         viols = {"hi":
-                     {"name": "Hot",
+                     {"name": f"Hot ({self.plan_hi_limit} C)",
                       "type": "Max",
                       "values": hi_viols}
                  }
@@ -500,7 +497,7 @@ class ACISThermalCheck(object):
             lo_viols = self._make_prediction_viols(times, temp, load_start,
                                                    self.plan_lo_limit,
                                                    "planning", "min")
-            viols["lo"] = {"name": "Cold",
+            viols["lo"] = {"name": f"Cold ({self.plan_lo_limit} C)",
                            "type": "Min",
                            "values": lo_viols}
 
@@ -1094,8 +1091,7 @@ class ACISThermalCheck(object):
                     msid=self.msid.upper(),
                     name=self.name.upper(),
                     hist_limit=self.hist_limit)
-        if self.msid != "fptemp":
-            proc["msid_limit"] = self.plan_hi_limit
+
         # Figure out the MD5 sum of model spec file
         md5sum = hashlib.md5(open(args.model_spec, 'rb').read()).hexdigest()
         pkg_version = ska_helpers.get_version("{}_check".format(self.name))

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -649,7 +649,6 @@ class ACISThermalCheck(object):
         plots['pow_sim']['ax'].lines[0].set_label('CCDs')
         plots['pow_sim']['ax'].lines[1].set_label('FEPs')
         plots['pow_sim']['ax'].legend(fancybox=True, framealpha=0.5, loc=2)
-        paint_perigee(self.perigee_passages, states, plots, "pow_sim")
         plots['pow_sim']['filename'] = 'pow_sim.png'
 
         # Make a plot of off-nominal roll
@@ -663,7 +662,6 @@ class ACISThermalCheck(object):
             ylabel='Roll Angle (deg)',
             ylim=(-20.0, 20.0),
             figsize=figsize, width=w1, load_start=load_start)
-        paint_perigee(self.perigee_passages, states, plots, "roll")
         plots['roll']['filename'] = 'roll.png'
 
     def make_prediction_plots(self, outdir, states, temps, load_start):
@@ -700,27 +698,25 @@ class ACISThermalCheck(object):
         plots[self.name] = plot_two(fig_id=1, x=times, y=temps[self.name],
                                     x2=times,
                                     y2=self.predict_model.comp["pitch"].mvals,
-                                    title=self.msid.upper(), xmin=plot_start,
-                                    xlabel='Date', ylabel='Temperature (C)',
+                                    xmin=plot_start, xlabel='Date', 
+                                    ylabel='Temperature (C)',
                                     ylabel2='Pitch (deg)', ylim2=(40, 180),
                                     width=w1, load_start=load_start)
         # Add horizontal lines for the planning and caution limits
         ymin, ymax = plots[self.name]['ax'].get_ylim()
         ymax = max(self.yellow_hi_limit+1, ymax)
-        plots[self.name]['ax'].axhline(self.yellow_hi_limit, linestyle='-', color='gold',
-                                       linewidth=2.0)
-        plots[self.name]['ax'].axhline(self.plan_hi_limit, linestyle='-', 
-                                       color='C2', linewidth=2.0)
+        plots[self.name]['ax'].set_title(self.msid.upper(), loc='left', pad=10)
+        plots[self.name]['ax'].axhline(self.yellow_hi_limit, linestyle='-',
+                                       color='gold', linewidth=2.0, label='Yellow')
+        plots[self.name]['ax'].axhline(self.plan_hi_limit, linestyle='-',
+                                       color='C2', linewidth=2.0, label='Planning')
         if self.flag_cold_viols:
             ymin = min(self.yellow_lo_limit-1, ymin)
-            plots[self.name]['ax'].axhline(self.yellow_lo_limit, linestyle='-', color='gold',
-                                           linewidth=2.0, zorder=-8)
+            plots[self.name]['ax'].axhline(self.yellow_lo_limit, linestyle='-',
+                                           color='gold', linewidth=2.0, zorder=-8)
             plots[self.name]['ax'].axhline(self.plan_lo_limit, linestyle='-',
                                            color='C2', linewidth=2.0, zorder=-8)
         plots[self.name]['ax'].set_ylim(ymin, ymax)
-        # Now plot any perigee passages that occur between xmin and xmax
-        # for eachpassage in perigee_passages:
-        paint_perigee(self.perigee_passages, states, plots, self.name)
         plots[self.name]['filename'] = self.msid.lower()+'.png'
 
         # The next line is to ensure that the width of the axes
@@ -735,6 +731,18 @@ class ACISThermalCheck(object):
         # This call allows the specific check tool
         # to customize plots after the fact
         self.custom_prediction_plots(plots)
+
+        # Make the legend on the temperature plot
+        # only now after we've allowed for
+        # customizations
+        nlegend = len(plots['default']['ax'].lines)-1
+        plots['default']['ax'].legend(bbox_to_anchor=(0.15, 0.99),
+                                      loc='lower left',
+                                      ncol=nlegend, fontsize=14)
+
+        # Now plot any perigee passages that occur between xmin and xmax
+        # for eachpassage in perigee_passages:
+        paint_perigee(self.perigee_passages, states, plots)
 
         # Now write all of the plots after possible
         # customizations have been made

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -919,8 +919,8 @@ class ACISThermalCheck(object):
                                zorder=-8, linewidth=2, label='Planning')
                     ymax = max(self.yellow_hi_limit+1, ymax)
                     if self.flag_cold_viols:
-                        ax.axhline(self.yellow_lo_limit, linestyle='-', color='gold')
-                        ax.axhline(self.plan_lo_limit, linestyle='-', color='C2')
+                        ax.axhline(self.yellow_lo_limit, linestyle='-', color='gold', linewidth=2)
+                        ax.axhline(self.plan_lo_limit, linestyle='-', color='C2', linewidth=2)
                         ymin = min(self.yellow_lo_limit-1, ymin)
                 ax.set_ylim(ymin, ymax)
             ax.set_xlim(xmin, xmax)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -909,10 +909,10 @@ class ACISThermalCheck(object):
                                linewidth=2)
                     ymax = max(self.acis_hot_limit+1, ymax)
                 else:
-                    ax.axhline(self.yellow_hi_limit, linestyle='-', color='gold', 
-                               zorder=-8, linewidth=2)
-                    ax.axhline(self.plan_hi_limit, linestyle='-', color='C2', 
-                               zorder=-8, linewidth=2)
+                    ax.axhline(self.yellow_hi_limit, linestyle='-', color='gold',
+                               zorder=-8, linewidth=2, label='Yellow')
+                    ax.axhline(self.plan_hi_limit, linestyle='-', color='C2',
+                               zorder=-8, linewidth=2, label='Planning')
                     ymax = max(self.yellow_hi_limit+1, ymax)
                     if self.flag_cold_viols:
                         ax.axhline(self.yellow_lo_limit, linestyle='-', color='y')

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -802,6 +802,8 @@ class ACISThermalCheck(object):
         run_start : string
             The starting date/time of the run.
         """
+        import pickle
+
         start = tlm['date'][0]
         stop = tlm['date'][-1]
         states = self.state_builder.get_validation_states(start, stop)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -506,11 +506,11 @@ class ACISThermalCheck(object):
 
         # Handle any additional violations one wants to check,
         # can be overridden by a subclass
-        self.custom_prediction_viols(times, temp, viols)
+        self.custom_prediction_viols(times, temp, viols, load_start)
 
         return viols
 
-    def custom_prediction_viols(self, times, temp, viols):
+    def custom_prediction_viols(self, times, temp, viols, load_start):
         """
         This method is here to allow a subclass
         to handle its own violations.
@@ -523,6 +523,10 @@ class ACISThermalCheck(object):
             The predicted temperatures
         viols : dict
             Dictionary of violations information to add to
+        load_start : float
+            The start time of the load, used so that we only report
+            violations for times later than this time for the model
+            run.
         """
         pass
 

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -455,6 +455,7 @@ class ACISThermalCheck(object):
             if in_load and duration >= 10.0:
                 viol = {'datestart': datestart,
                         'datestop': datestop,
+                        'duration': duration*1.0e-3,
                         'extemp': op(temp[change[0]:change[1]])}
                 mylog.info('WARNING: %s violates %s limit ' % (self.msid,
                                                                lim_name) +

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -651,7 +651,6 @@ class ACISThermalCheck(object):
         plots['pow_sim']['ax'].legend(fancybox=True, framealpha=0.5, loc=2)
         paint_perigee(self.perigee_passages, states, plots, "pow_sim")
         plots['pow_sim']['filename'] = 'pow_sim.png'
-        filename = 'pow_sim.png'
 
         # Make a plot of off-nominal roll
         plots['roll'] = plot_one(
@@ -859,7 +858,8 @@ class ACISThermalCheck(object):
         quant_head = ",".join(['MSID'] + ["quant%d" % x for x in quantiles])
         quant_table += quant_head + "\n"
         xmin, xmax = cxctime2plotdate(model.times)[[0, -1]]
-        for fig_id, msid in enumerate(pred.keys()):
+        fig_id = 0
+        for msid in pred.keys():
             plot = dict(msid=msid.upper())
             fig = plt.figure(10 + fig_id, figsize=(12, 6))
             fig.clf()
@@ -950,7 +950,7 @@ class ACISThermalCheck(object):
             plot['hist'] = {'fig': fig,
                             "ax": ax,
                             'filename': '%s_valid_hist.png' % msid}
-
+            fig_id += 1
             plots.append(plot)
 
         fig = plt.figure(10+fig_id, figsize=(12, 6))

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -881,10 +881,6 @@ class ACISThermalCheck(object):
                 ax.set_title(msid.upper() + ' residuals: data - model')
                 ax.set_xlabel(labels[msid])
             fig.subplots_adjust(bottom=0.18, left=0.15, wspace=0.6)
-            filename = '%s_valid_hist.png' % msid
-            outfile = os.path.join(outdir, filename)
-            mylog.info('Writing plot file %s' % outfile)
-            fig.savefig(outfile)
             plot['hist'] = {'fig': fig,
                             "ax": ax,
                             'filename': '%s_valid_hist.png' % msid}

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1108,21 +1108,18 @@ class ACISThermalCheck(object):
             Dictionary of items which will be written to the ReST file.
         """
         import jinja2
-        if self.msid == "fptemp":
-            import acisfp_check
-            template_path = os.path.join(os.path.dirname(acisfp_check.__file__), 'templates')
-        else:
-            template_path = os.path.join(TASK_DATA, 'acis_thermal_check',
-                                         'templates')
+        template_path = os.path.join(TASK_DATA, 'acis_thermal_check',
+                                     'templates', 'index_template.rst')
         outfile = os.path.join(outdir, 'index.rst')
         mylog.info('Writing report file %s' % outfile)
         # Open up the reST template and send the context to it using jinja2
-        index_template = open(os.path.join(template_path,
-                                           'index_template.rst')).read()
-        index_template = re.sub(r' %}\n', ' %}', index_template)
-        template = jinja2.Template(index_template)
+        with open(template_path) as fin:
+            index_template = fin.read()
+            index_template = re.sub(r' %}\n', ' %}', index_template)
+            template = jinja2.Template(index_template)
         # Render the template and write it to a file
-        open(outfile, 'w').write(template.render(**context))
+        with open(outfile, "w") as fout:
+            fout.write(template.render(**context))
 
     def _setup_proc_and_logger(self, args):
         """

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -919,8 +919,8 @@ class ACISThermalCheck(object):
                                zorder=-8, linewidth=2, label='Planning')
                     ymax = max(self.yellow_hi_limit+1, ymax)
                     if self.flag_cold_viols:
-                        ax.axhline(self.yellow_lo_limit, linestyle='-', color='y')
-                        ax.axhline(self.plan_lo_limit, linestyle='--', color='y')
+                        ax.axhline(self.yellow_lo_limit, linestyle='-', color='gold')
+                        ax.axhline(self.plan_lo_limit, linestyle='-', color='C2')
                         ymin = min(self.yellow_lo_limit-1, ymin)
                 ax.set_ylim(ymin, ymax)
             ax.set_xlim(xmin, xmax)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -504,7 +504,27 @@ class ACISThermalCheck(object):
                            "type": "Min",
                            "values": lo_viols}
 
+        # Handle any additional violations one wants to check,
+        # can be overridden by a subclass
+        self.custom_prediction_viols(times, temp, viols)
+
         return viols
+
+    def custom_prediction_viols(self, times, temp, viols):
+        """
+        This method is here to allow a subclass
+        to handle its own violations.
+
+        Parameters
+        ----------
+        times : NumPy array
+            The times for the predicted temperatures
+        temp : NumPy array
+            The predicted temperatures
+        viols : dict
+            Dictionary of violations information to add to
+        """
+        pass
 
     def write_states(self, outdir, states):
         """

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -699,7 +699,7 @@ class ACISThermalCheck(object):
                                     x2=times,
                                     y2=self.predict_model.comp["pitch"].mvals,
                                     xmin=plot_start, xlabel='Date', 
-                                    ylabel='Temperature (C)',
+                                    ylabel='Temperature ($^\circ$C)',
                                     ylabel2='Pitch (deg)', ylim2=(40, 180),
                                     width=w1, load_start=load_start)
         # Add horizontal lines for the planning and caution limits
@@ -735,10 +735,9 @@ class ACISThermalCheck(object):
         # Make the legend on the temperature plot
         # only now after we've allowed for
         # customizations
-        nlegend = len(plots['default']['ax'].lines)-1
-        plots['default']['ax'].legend(bbox_to_anchor=(0.15, 0.99),
+        plots['default']['ax'].legend(bbox_to_anchor=(0.25, 0.99),
                                       loc='lower left',
-                                      ncol=nlegend, fontsize=14)
+                                      ncol=4, fontsize=14)
 
         # Now plot any perigee passages that occur between xmin and xmax
         # for eachpassage in perigee_passages:
@@ -832,10 +831,10 @@ class ACISThermalCheck(object):
         tlm = tlm[idxs]
 
         # Set up labels for validation plots
-        labels = {self.msid: 'Degrees (C)',
-                  'pitch': 'Pitch (degrees)',
+        labels = {self.msid: 'Temperature ($^\circ$C)',
+                  'pitch': 'Pitch (deg)',
                   'tscpos': 'SIM-Z (steps/1000)',
-                  'roll': 'Off-Nominal Roll (degrees)'}
+                  'roll': 'Off-Nominal Roll (deg)'}
 
         scales = {'tscpos': 1000.}
 
@@ -872,15 +871,15 @@ class ACISThermalCheck(object):
             fig = plt.figure(10 + fig_id, figsize=(12, 6))
             fig.clf()
             scale = scales.get(msid, 1.0)
-            ticklocs, fig, ax = plot_cxctime(model.times, pred[msid] / scale,
+            ticklocs, fig, ax = plot_cxctime(model.times, pred[msid] / scale, label='Model',
                                              fig=fig, ls='-', lw=4, color=thermal_red)
-            ticklocs, fig, ax = plot_cxctime(model.times, tlm[msid] / scale,
+            ticklocs, fig, ax = plot_cxctime(model.times, tlm[msid] / scale, label='Data',
                                              fig=fig, ls='-', lw=2, color=thermal_blue)
             if np.any(~good_mask):
                 ticklocs, fig, ax = plot_cxctime(model.times[~good_mask],
                                                  tlm[msid][~good_mask] / scale,
                                                  fig=fig, fmt='.c')
-            ax.set_title(msid.upper() + ' validation; data: blue, model: red')
+            ax.set_title(msid.upper() + ' validation', loc='left', pad=10)
             ax.set_xlabel("Date")
             ax.set_ylabel(labels[msid])
             ax.grid()
@@ -896,13 +895,17 @@ class ACISThermalCheck(object):
             if self.msid == msid:
                 ymin, ymax = ax.get_ylim()
                 if msid == "fptemp":
-                    ax.axhline(self.cold_ecs_limit, linestyle='-.', color='dodgerblue',
+                    ax.axhline(self.cold_ecs_limit, linestyle='--',
+                               color='dodgerblue', label='Cold ECS',
                                zorder=-8, linewidth=2)
-                    ax.axhline(self.acis_i_limit, linestyle='-.', color='purple', zorder=-8,
+                    ax.axhline(self.acis_i_limit, linestyle='--',
+                               color='purple', zorder=-8, label='ACIS-I',
                                linewidth=2)
-                    ax.axhline(self.acis_s_limit, linestyle='-.', color='blue', zorder=-8,
+                    ax.axhline(self.acis_s_limit, linestyle='--', 
+                               color='blue', zorder=-8, label='ACIS-S',
                                linewidth=2)
-                    ax.axhline(self.acis_hot_limit, linestyle='-.', color='red', zorder=-8,
+                    ax.axhline(self.acis_hot_limit, linestyle='--', 
+                               color='red', zorder=-8, label='Hot ACIS',
                                linewidth=2)
                     ymax = max(self.acis_hot_limit+1, ymax)
                 else:
@@ -917,6 +920,7 @@ class ACISThermalCheck(object):
                         ymin = min(self.yellow_lo_limit-1, ymin)
                 ax.set_ylim(ymin, ymax)
             ax.set_xlim(xmin, xmax)
+
             plot['lines'] = {"fig": fig,
                              "ax": ax,
                              "filename": msid + '_valid.png'}
@@ -1025,6 +1029,14 @@ class ACISThermalCheck(object):
         # This call allows the specific check tool
         # to customize plots after the fact
         self.custom_validation_plots(plots)
+
+        if self.msid == "fptemp":
+            anchor = (0.295, 0.99)
+        else:
+            anchor = (0.4, 0.99)
+        plots[0]["lines"]["ax"].legend(bbox_to_anchor=anchor,
+                                       loc='lower left',
+                                       ncol=3, fontsize=14)
 
         # Now write all of the plots after possible
         # customizations have been made

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -752,9 +752,14 @@ class ACISThermalCheck(object):
 
     def custom_prediction_plots(self, plots):
         """
-        This is a stub for customizing 
-        prediction plots that can be overriden
-        by a subclass
+        Customization of prediction plots.
+
+        Parameters
+        ----------
+        plots : dict of dicts
+            Contains the hooks to the plot figures, axes, and filenames
+            and can be used to customize plots before they are written,
+            e.g. add limit lines, etc.
         """
         pass
 
@@ -1068,9 +1073,14 @@ class ACISThermalCheck(object):
 
     def custom_validation_plots(self, plots):
         """
-        This is a stub for customizing 
-        validation plots that can be overriden
-        by a subclass
+        Customization of prediction plots.
+
+        Parameters
+        ----------
+        plots : dict of dicts
+            Contains the hooks to the plot figures, axes, and filenames
+            and can be used to customize plots before they are written,
+            e.g. add limit lines, etc.
         """
         pass
 

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -381,10 +381,12 @@ class RegressionTester(object):
         if answer_store:
             viol_data["datestarts"] = []
             viol_data["datestops"] = []
+            viol_data["duration"] = []
             viol_data["temps"] = []
             if self.msid == "fptemp":
                 viol_data["obsids"] = []
         load_year = "20%s" % load_week[-3:-1]
+        next_year = f"{int(load_year)+1}"
         self.run_model(load_week, run_start=viol_data['run_start'], 
                        override_limits=viol_data['limits'])
         out_dir = os.path.join(self.outdir, load_week)
@@ -394,18 +396,20 @@ class RegressionTester(object):
             for line in myfile.readlines():
                 if line.startswith("Model status"):
                     assert "NOT OK" in line
-                if line.startswith(load_year):
+                if line.startswith(load_year) or line.startswith(next_year):
                     if answer_store:
                         words = line.strip().split()
                         viol_data["datestarts"].append(words[0])
                         viol_data["datestops"].append(words[1])
-                        viol_data["temps"].append(words[2])
+                        viol_data["duration"].append(words[2])
+                        viol_data["temps"].append(words[3])
                         if self.msid == "fptemp":
-                            viol_data["obsids"].append(words[3])
+                            viol_data["obsids"].append(words[4])
                     else:
                         try:
                             assert viol_data["datestarts"][i] in line
                             assert viol_data["datestops"][i] in line
+                            assert viol_data["duration"][i] in line
                             assert viol_data["temps"][i] in line
                             if self.msid == "fptemp":
                                 assert viol_data["obsids"][i] in line

--- a/acis_thermal_check/regression_testing.py
+++ b/acis_thermal_check/regression_testing.py
@@ -2,7 +2,6 @@ import os
 from numpy.testing import assert_array_equal, \
     assert_allclose
 import shutil
-import numpy as np
 import tempfile
 import pickle
 from pathlib import Path

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -99,13 +99,6 @@ CCD/FEP Count
 
 .. image:: {{plot.lines.filename}}
 
-{% elif plot.msid == "earthheat__fptemp" %}
-
-Earth Solid Angle
------------------
-
-.. image:: {{plot.lines.filename}}
-
 {% else %}
 
 {{ plot.msid }}

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -78,7 +78,13 @@ No {{proc.msid}} {{viols[key]["name"]}} Violations
 MSID quantiles
 ---------------
 
-Note: {{proc.name}} quantiles are calculated using only points where {{proc.msid}} > {{proc.hist_limit.0}} degC.
+{% if proc.msid == "FPTEMP" %}
+{% set quan_text = proc.hist_limit.0|join(" C <= FPTEMP <= ") + " C" %}
+{% else %}
+{% set quan_text = proc.msid + " >= " ~ proc.hist_limit.0 + " C" %}
+{% endif %}
+
+Note: Quantiles are calculated using only points where {{quan_text}}.
 
 .. csv-table:: 
    :header: "MSID", "1%", "5%", "16%", "50%", "84%", "95%", "99%"
@@ -129,11 +135,14 @@ Earth Solid Angle
 -----------------------
 
 {% if plot.msid == proc.msid %}
-{% if proc.hist_limit|length == 2 %}
-Note: {{proc.name}} residual histograms include points where {{proc.msid}} {{proc.op.0}} {{proc.hist_limit.0}} degC in blue and points where {{proc.msid}} {{proc.op.1}} {{proc.hist_limit.1}} degC in red.
+{% if proc.msid == "FPTEMP" %}
+{% set hist_string = proc.hist_limit.0|join(" C <= FPTEMP <= ") + " C" %}
+{% elif proc.hist_limit|length == 2 %}
+{% set hist_string = proc.msid + " " ~ proc.op.0 + " " ~ proc.hist_limit.0 + " C in blue and points where " ~ proc.msid + " " ~ proc.op.1 + " " ~ proc.hist_limit.1 + " C in red" %}
 {% else %}
-Note: {{proc.name}} residual histograms include only points where {{proc.msid}} {{proc.op.0}} {{proc.hist_limit.0}} degC.
+{% set hist_string = proc.msid + " " ~ proc.op.0 + " " ~ proc.hist_limit.0 + " C" %}
 {% endif %}
+Note: {{proc.msid}} residual histograms include only points where {{hist_string}}.
 {% endif %}
 
 .. image:: {{plot.lines.filename}}

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -18,7 +18,7 @@ Summary
 =====================  =============================================
 Date start             {{proc.datestart}}
 Date stop              {{proc.datestop}}
-Model status           {%if any_viols %}:red:`NOT OK`{% else %}OK{% endif%} (Planning Limit = {{"%.1f"|format(proc.msid_limit)}} C)
+Model status           {%if any_viols %}:red:`NOT OK`{% else %}OK{% endif%}
 {% if bsdir %}
 Load directory         {{bsdir}}
 {% endif %}
@@ -32,7 +32,7 @@ States                 `<states.dat>`_
 
 {% if viols[key]["values"]|length > 0 %}
 {{proc.msid}} {{viols[key]["name"]}} Violations
------------------------------
+---------------------------------------------------
 =====================  =====================  ===================
 Date start             Date stop              {{viols[key]["type"]}} Temperature
 =====================  =====================  ===================

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -18,7 +18,7 @@ Summary
 =====================  =============================================
 Date start             {{proc.datestart}}
 Date stop              {{proc.datestop}}
-Model status           {%if viols.hi or viols.lo %}:red:`NOT OK`{% else %}OK{% endif%} (Planning Limit = {{"%.1f"|format(proc.msid_limit)}} C)
+Model status           {%if any_viols %}:red:`NOT OK`{% else %}OK{% endif%} (Planning Limit = {{"%.1f"|format(proc.msid_limit)}} C)
 {% if bsdir %}
 Load directory         {{bsdir}}
 {% endif %}
@@ -28,35 +28,23 @@ Temperatures           `<temperatures.dat>`_
 States                 `<states.dat>`_
 =====================  =============================================
 
-{% if viols.hi  %}
-{{proc.msid}} Hot Violations
+{% for key in viols.keys() %}
+
+{% if viols[key]["values"]|length > 0 %}
+{{proc.msid}} {{viols[key]["name"]}} Violations
 -----------------------------
-=====================  =====================  ==================
-Date start             Date stop              Max temperature
-=====================  =====================  ==================
-{% for viol in viols.hi %}
-{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.maxtemp)}}
+=====================  =====================  ===================
+Date start             Date stop              {{viols[key]["type"]}} Temperature
+=====================  =====================  ===================
+{% for viol in viols[key]["values"] %}
+{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.extemp)}}
 {% endfor %}
-=====================  =====================  ==================
+=====================  =====================  ===================
 {% else %}
-No {{proc.msid}} Hot Violations
+No {{proc.msid}} {{viols[key]["name"]}} Violations
 {% endif %}
 
-{% if flag_cold %}
-{% if viols.lo  %}
-{{proc.msid}} Cold Violations
-------------------------------
-=====================  =====================  ==================
-Date start             Date stop              Min temperature
-=====================  =====================  ==================
-{% for viol in viols.lo %}
-{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.mintemp)}}
 {% endfor %}
-=====================  =====================  ==================
-{% else %}
-No {{proc.msid}} Cold Violations
-{% endif %}
-{% endif %}
 
 .. image:: {{plots.default.filename}}
 .. image:: {{plots.pow_sim.filename}}
@@ -109,14 +97,14 @@ No Validation Violations
 CCD/FEP Count
 -------------
 
-.. image:: {{plot.lines}}
+.. image:: {{plot.lines.filename}}
 
 {% elif plot.msid == "earthheat__fptemp" %}
 
 Earth Solid Angle
 -----------------
 
-.. image:: {{plot.lines}}
+.. image:: {{plot.lines.filename}}
 
 {% else %}
 
@@ -131,8 +119,8 @@ Note: {{proc.name}} residual histograms include only points where {{proc.msid}} 
 {% endif %}
 {% endif %}
 
-.. image:: {{plot.lines}}
-.. image:: {{plot.hist}}
+.. image:: {{plot.lines.filename}}
+.. image:: {{plot.hist.filename}}
 
 {% endif %}
 

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -25,6 +25,9 @@ Load directory         {{bsdir}}
 Run time               {{proc.run_time}} by {{proc.run_user}}
 Run log                `<run.dat>`_
 Temperatures           `<temperatures.dat>`_
+{% if proc.msid == "FPTEMP" %}
+Earth Solid Angles     `<earth_solid_angles.dat>`_
+{% endif %}
 States                 `<states.dat>`_
 =====================  =============================================
 
@@ -33,6 +36,15 @@ States                 `<states.dat>`_
 {% if viols[key]["values"]|length > 0 %}
 {{proc.msid}} {{viols[key]["name"]}} Violations
 ---------------------------------------------------
+{% if proc.msid == "FPTEMP" %}
+=====================  =====================  =================  ==================  ==================
+Date start             Date stop              Duration (ks)      Max temperature     Obsids
+=====================  =====================  =================  ==================  ==================
+{% for viol in viols[key]["values"] %}
+{{viol.datestart}}  {{viol.datestop}}  {{"{:3.2f}".format(viol.duration).rjust(8)}}            {{"%.2f"|format(viol.extemp)}}             {{viol.obsid}}
+{% endfor %}
+=====================  =====================  =================  ==================  ==================
+{% else %}
 =====================  =====================  =================  ===================
 Date start             Date stop              Duration (ks)      {{viols[key]["type"]}} Temperature
 =====================  =====================  =================  ===================
@@ -40,6 +52,7 @@ Date start             Date stop              Duration (ks)      {{viols[key]["t
 {{viol.datestart}}  {{viol.datestop}}  {{"{:3.2f}".format(viol.duration).rjust(8)}}           {{"{:.2f}".format(viol.extemp)}}
 {% endfor %}
 =====================  =====================  =================  ===================
+{% endif %}
 {% else %}
 No {{proc.msid}} {{viols[key]["name"]}} Violations
 {% endif %}
@@ -48,7 +61,11 @@ No {{proc.msid}} {{viols[key]["name"]}} Violations
 
 .. image:: {{plots.default.filename}}
 .. image:: {{plots.pow_sim.filename}}
+{% if proc.msid == "FPTEMP" %}
+.. image:: {{plots.roll_taco.filename}}
+{% else %}
 .. image:: {{plots.roll.filename}}
+{% endif %}
 
 {% endif %}
 
@@ -99,6 +116,13 @@ CCD/FEP Count
 
 .. image:: {{plot.lines.filename}}
 
+{% elif plot.msid == "earthheat__fptemp" %}
+
+Earth Solid Angle
+-----------------
+
+.. image:: {{plot.lines.filename}}
+
 {% else %}
 
 {{ plot.msid }}
@@ -118,5 +142,17 @@ Note: {{proc.name}} residual histograms include only points where {{proc.msid}} 
 {% endif %}
 
 {% endfor %}
+
+{% if proc.msid == "FPTEMP" %}
+
+ADDITIONAL PLOTS
+-----------------------
+
+Additional plots of FPTEMP vs TIME for different temperature ranges
+
+.. image:: fptempM120toM119.png
+.. image:: fptempM120toM90.png
+
+{% endif %}
 
 {% endif %}

--- a/acis_thermal_check/templates/index_template.rst
+++ b/acis_thermal_check/templates/index_template.rst
@@ -33,13 +33,13 @@ States                 `<states.dat>`_
 {% if viols[key]["values"]|length > 0 %}
 {{proc.msid}} {{viols[key]["name"]}} Violations
 ---------------------------------------------------
-=====================  =====================  ===================
-Date start             Date stop              {{viols[key]["type"]}} Temperature
-=====================  =====================  ===================
+=====================  =====================  =================  ===================
+Date start             Date stop              Duration (ks)      {{viols[key]["type"]}} Temperature
+=====================  =====================  =================  ===================
 {% for viol in viols[key]["values"] %}
-{{viol.datestart}}  {{viol.datestop}}  {{"%.2f"|format(viol.extemp)}}
+{{viol.datestart}}  {{viol.datestop}}  {{"{:3.2f}".format(viol.duration).rjust(8)}}           {{"{:.2f}".format(viol.extemp)}}
 {% endfor %}
-=====================  =====================  ===================
+=====================  =====================  =================  ===================
 {% else %}
 No {{proc.msid}} {{viols[key]["name"]}} Violations
 {% endif %}

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -503,7 +503,7 @@ def get_acis_limits(msid):
 
 def paint_perigee(perigee_passages, states, plots):
     """
-    This function draws vertical dahsed lines for EEF, Perigee and XEF
+    This function draws vertical dashed lines for EEF, Perigee and XEF
     events in the load.EEF and XEF lines are black; Perigee is red.
 
     You supply the list of perigee passage events which are:

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -500,12 +500,8 @@ def get_acis_limits(msid):
 
     return yellow_lo, yellow_hi, margin
 
-#----------------------------------------------------------------------
-#
-#   paint_perigee
-#
-#----------------------------------------------------------------------
-def paint_perigee(perigee_passages, states, plots, msid):
+
+def paint_perigee(perigee_passages, states, plots):
     """
     This function draws vertical dahsed lines for EEF, Perigee and XEF
     events in the load.EEF and XEF lines are black; Perigee is red.
@@ -523,21 +519,25 @@ def paint_perigee(perigee_passages, states, plots, msid):
     #
     # Now plot any perigee passages that occur between xmin and xmax
     from Chandra.Time import DateTime
-    for eachpassage in perigee_passages:
-        # The index [1] item is always the Perigee Passage time. Draw that line in red
-        # If this line is between tstart and tstop then it needs to be drawn
-        # on the plot. otherwise ignore
-        if states['tstop'][-1] >= DateTime(eachpassage[0]).secs >= states['tstart'][0]:
-            # Have to convert this time into the new x axis time scale necessitated by SKA
-            xpos = cxctime2plotdate([DateTime(eachpassage[0]).secs])
+    for plot in plots.values():
+        for eachpassage in perigee_passages:
+            # The index [1] item is always the Perigee Passage time. Draw that
+            # line in red If this line is between tstart and tstop then it
+            # needs to be drawn on the plot. otherwise ignore
+            if states['tstop'][-1] >= DateTime(eachpassage[0]).secs >= states['tstart'][0]:
+                # Have to convert this time into the new x axis time scale
+                # necessitated by SKA
+                xpos = cxctime2plotdate([DateTime(eachpassage[0]).secs])
 
-            ymin, ymax = plots[msid]['ax'].get_ylim()
+                ymin, ymax = plot['ax'].get_ylim()
 
-            # now plot the line.
-            plots[msid]['ax'].vlines(xpos, ymin, ymax, linestyle=':', color='red', linewidth=2.0)
+                # now plot the line.
+                plot['ax'].vlines(xpos, ymin, ymax, linestyle=':', color='red',
+                                  linewidth=2.0)
 
-            # Plot the perigee passage time so long as it was specified in the CTI_report file
-            if eachpassage[1] != "Not-within-load":
-                perigee_time = cxctime2plotdate([DateTime(eachpassage[1]).secs])
-                plots[msid]['ax'].vlines(perigee_time, ymin, ymax, linestyle=':',
-                                         color='black', linewidth=2.0)
+                # Plot the perigee passage time so long as it was specified in
+                # the CTI_report file
+                if eachpassage[1] != "Not-within-load":
+                    perigee_time = cxctime2plotdate([DateTime(eachpassage[1]).secs])
+                    plot['ax'].vlines(perigee_time, ymin, ymax, linestyle=':',
+                                      color='black', linewidth=2.0)

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -518,16 +518,16 @@ def paint_perigee(perigee_passages, states, plots):
     """
     #
     # Now plot any perigee passages that occur between xmin and xmax
-    from Chandra.Time import DateTime
+    from cxotime import CxoTime
     for plot in plots.values():
         for eachpassage in perigee_passages:
             # The index [1] item is always the Perigee Passage time. Draw that
             # line in red If this line is between tstart and tstop then it
             # needs to be drawn on the plot. otherwise ignore
-            if states['tstop'][-1] >= DateTime(eachpassage[0]).secs >= states['tstart'][0]:
+            if states['tstop'][-1] >= CxoTime(eachpassage[0]).secs >= states['tstart'][0]:
                 # Have to convert this time into the new x axis time scale
                 # necessitated by SKA
-                xpos = cxctime2plotdate([DateTime(eachpassage[0]).secs])
+                xpos = cxctime2plotdate([CxoTime(eachpassage[0]).secs])
 
                 ymin, ymax = plot['ax'].get_ylim()
 
@@ -538,6 +538,6 @@ def paint_perigee(perigee_passages, states, plots):
                 # Plot the perigee passage time so long as it was specified in
                 # the CTI_report file
                 if eachpassage[1] != "Not-within-load":
-                    perigee_time = cxctime2plotdate([DateTime(eachpassage[1]).secs])
+                    perigee_time = cxctime2plotdate([CxoTime(eachpassage[1]).secs])
                     plot['ax'].vlines(perigee_time, ymin, ymax, linestyle=':',
                                       color='black', linewidth=2.0)

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -499,3 +499,45 @@ def get_acis_limits(msid):
             break
 
     return yellow_lo, yellow_hi, margin
+
+#----------------------------------------------------------------------
+#
+#   paint_perigee
+#
+#----------------------------------------------------------------------
+def paint_perigee(perigee_passages, states, plots, msid):
+    """
+    This function draws vertical dahsed lines for EEF, Perigee and XEF
+    events in the load.EEF and XEF lines are black; Perigee is red.
+
+    You supply the list of perigee passage events which are:
+        Radzone Start/Stop time
+        Perigee Passage time
+
+        The states you created in main
+
+        The dictionary of plots you created
+
+        The MSID (in this case FP_TEMP) used to access the dictionary
+    """
+    #
+    # Now plot any perigee passages that occur between xmin and xmax
+    from Chandra.Time import DateTime
+    for eachpassage in perigee_passages:
+        # The index [1] item is always the Perigee Passage time. Draw that line in red
+        # If this line is between tstart and tstop then it needs to be drawn
+        # on the plot. otherwise ignore
+        if states['tstop'][-1] >= DateTime(eachpassage[0]).secs >= states['tstart'][0]:
+            # Have to convert this time into the new x axis time scale necessitated by SKA
+            xpos = cxctime2plotdate([DateTime(eachpassage[0]).secs])
+
+            ymin, ymax = plots[msid]['ax'].get_ylim()
+
+            # now plot the line.
+            plots[msid]['ax'].vlines(xpos, ymin, ymax, linestyle=':', color='red', linewidth=2.0)
+
+            # Plot the perigee passage time so long as it was specified in the CTI_report file
+            if eachpassage[1] != "Not-within-load":
+                perigee_time = cxctime2plotdate([DateTime(eachpassage[1]).secs])
+                plots[msid]['ax'].vlines(perigee_time, ymin, ymax, linestyle=':',
+                                         color='black', linewidth=2.0)


### PR DESCRIPTION
## Description

This rather large PR makes a number of enhancements and improvements to ``acis_thermal_check``, which were originally driven by the need to implement checking of violations of the new thermal limit of +12 C for turning on 3 FEPs when no FEPs are on for 1DPAMZT.

They are:

* All thermal limits are collected in a single `limits.yml` file, which can be easily edited. The naming scheme of the thermal limit attributes in the code has also been changed to ensure consistency. This also means the `get_acis_limits` function, which previously handled the limits by checking datafiles on the HEAD LAN, has been removed. 
* Three new customization methods are added to the `ACISThermalCheck` class, which are stubs by default and can be overridden by subclasses (e.g. `DPACheck`):
   * `custom_prediction_viols`, which allows the subclass to implement its own thermal limit violation conditions
   * `custom_prediction_plots`, which allows the subclass to make specialized customizations to validation plots (adding lines for thermal limits, etc.)
   * `custom_validation_plots`, which allows the subclass to make specialized customizations to validation plots (adding lines for thermal limits, etc.)
* All thermal model tools (including `acisfp_check`) now use a single Jinja/ReST template, located in this repository.
* Adds legends to plots so that the lines can be more easily identified. 
* Uses `cxotime` instead of `Chandra.Time` to handle time.
* Violations less than 10 seconds will no longer be reported (this effectively catches violations which are reported as having a duration of zero seconds).
* Violation durations are now reported on the web pages, and these are checked for in regression testing. 
* Perigee passage information, which previously only appeared on the prediction plot for the FP model, now appear on all models.

This PR has accompanying PRs for other packages to follow. 

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
