### PR TITLE
Run on windows, change the cold ECS planning limit, fix bugs

### DIFF
--- a/acis_thermal_check/data/limits.yml
+++ b/acis_thermal_check/data/limits.yml
@@ -12,7 +12,7 @@
   yellow_hi: 56.0
   
 fptemp:
-  cold_ecs: -119.5
+  cold_ecs: -118.2
   acis_s: -111.0
   acis_i: -112.0
   acis_hot: -109.0

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -28,6 +28,8 @@ from acis_thermal_check.utils import \
     paint_perigee
 from kadi import events
 from astropy.table import Table
+import ska_helpers
+
 
 op_map = {"greater": ">",
           "greater_equal": ">=",
@@ -135,6 +137,12 @@ class ACISThermalCheck(object):
             to avoid it being used accidentally.
         """
         # First, record the selected state builder in the class attributes
+        if args.version:
+            pkg_version = ska_helpers.get_version("{}_check".format(self.name))
+            print(f"{self.name}_check version {pkg_version}")
+            print(f"acis_thermal_check version {version}")
+            return
+
         self.state_builder = make_state_builder(args.state_builder, args)
 
         proc = self._setup_proc_and_logger(args)
@@ -1161,7 +1169,6 @@ class ACISThermalCheck(object):
             The command-line options object, which has the options
             attached to it as attributes
         """
-        import ska_helpers
         import hashlib
         import json
 

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1093,7 +1093,7 @@ class ACISThermalCheck(object):
         pass
 
     def rst_to_html(self, outdir, proc):
-        """Run rst2html.py to render index.rst as HTML]
+        """Render index.rst as HTML
 
         Parameters
         ----------
@@ -1104,27 +1104,20 @@ class ACISThermalCheck(object):
             A dictionary of general information used in the output
         """
         # First copy CSS files to outdir
-        import Ska.Shell
         import docutils.writers.html4css1
+        from docutils.core import publish_file
         dirname = os.path.dirname(docutils.writers.html4css1.__file__)
         shutil.copy2(os.path.join(dirname, 'html4css1.css'), outdir)
 
         shutil.copy2(os.path.join(TASK_DATA, 'acis_thermal_check', 'templates',
                                   'acis_thermal_check.css'), outdir)
 
-        # Spawn a shell and call rst2html to generate HTML from the reST.
-        spawn = Ska.Shell.Spawn(stdout=None)
+        stylesheet_path = os.path.join(outdir, 'acis_thermal_check.css')
         infile = os.path.join(outdir, 'index.rst')
         outfile = os.path.join(outdir, 'index.html')
-        status = spawn.run(['rst2html.py',
-                            '--stylesheet-path={}'
-                            .format(os.path.join(outdir, 'acis_thermal_check.css')),
-                            infile, outfile])
-        if status != 0:
-            proc['errors'].append('rst2html.py failed with status {}: see run log'
-                                  .format(status))
-            mylog.error('rst2html.py failed')
-            mylog.error(''.join(spawn.outlines) + '\n')
+        publish_file(source_path=infile, destination_path=outfile, 
+                     writer_name="html", 
+                     settings_overrides={"stylesheet_path": stylesheet_path})
 
         # Remove the stupid <colgroup> field that docbook inserts.  This
         # <colgroup> prevents HTML table auto-sizing.

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -136,13 +136,13 @@ class ACISThermalCheck(object):
             This is deliberately hidden from command-line operation
             to avoid it being used accidentally.
         """
-        # First, record the selected state builder in the class attributes
         if args.version:
             pkg_version = ska_helpers.get_version("{}_check".format(self.name))
             print(f"{self.name}_check version {pkg_version}")
             print(f"acis_thermal_check version {version}")
             return
 
+        # First, record the selected state builder in the class attributes
         self.state_builder = make_state_builder(args.state_builder, args)
 
         proc = self._setup_proc_and_logger(args)

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -115,7 +115,7 @@ class SQLStateBuilder(StateBuilder):
         if os.path.isdir(self.backstop_file):
             # Returns a list but requires exactly 1 match
             backstop_file = get_globfiles(os.path.join(self.backstop_file,
-                                                       'CR*.backstop'))[0]
+                                                       'CR[0-9]*.backstop'))[0]
             self.backstop_file = backstop_file
 
         self.logger.info('Using backstop file %s' % self.backstop_file)

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -382,6 +382,10 @@ def get_options(name, model_path, opts=None):
 
     args = parser.parse_args()
 
+    if os.name == "nt" and args.state_builder == "acis":
+        # ACIS state builder does not work on Windows systems
+        args.state_builder = 'sql'
+
     if args.oflsdir is not None:
         args.backstop_file = args.oflsdir
 

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -382,10 +382,6 @@ def get_options(name, model_path, opts=None):
 
     args = parser.parse_args()
 
-    if os.name == "nt" and args.state_builder == "acis":
-        # ACIS state builder does not work on Windows systems
-        args.state_builder = 'sql'
-
     if args.oflsdir is not None:
         args.backstop_file = args.oflsdir
 


### PR DESCRIPTION
## Description

This PR enables `acis_thermal_check` to run on Windows and improves the code in a few other areas.

* Makes sure the glob for the backstop file is not case-sensitive.
* Use the docutils python module directly to write the index file.
* Make sure that the `--version` command-line argument actually works.
* Change the cold ECS planning limit to -118.2 C.

## Testing

- [x] Passes unit tests on macOS and Windows
- [x] Functional testing

Fixes #