### PR TITLE
Update for SCS-106 change and new power commands

### DIFF
--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -423,10 +423,12 @@ def make_state_builder(name, args):
     # Instantiate the ACIS OPS History Builder: ACISStateBuilder
     elif name == "acis":
         # Create a state builder using the ACIS Ops backstop history
-        # modules
+        # modules and send in some of the switches from the model invocation
+        # argument list
         state_builder = builder_class(interrupt=args.interrupt,
                                       backstop_file=args.backstop_file,
                                       nlet_file=args.nlet_file,
+                                      verbose = args.verbose,
                                       logger=mylog)
     else:
         raise RuntimeError("No such state builder with name %s!" % name)


### PR DESCRIPTION
## Description
Recently, SCS-106 was updated to leave 3 FEPs on rather than no FEPs on.
SCS-106 is run as part of the SCS-107 sequence. 

Therefore thermal model history assembly requires that this change be reflected
in any shutdown: both science-only shutdowns as well as Full Stops.  Also, the 
ACIS Team recently added new power commands which have to be handled by Backstop History.

These were the drivers for the release of this version of Backstop History. 
Several changes had been underway for some time and are incorporated in this release.



## Testing

- [x ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x ] Functional testing

Fixes #