### PR TITLE
Write .hist files to --outdir directory

### DIFF
--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -141,10 +141,11 @@ class ACISThermalCheck(object):
             print(f"acis_thermal_check version {version}")
             return
 
-        # First, record the selected state builder in the class attributes
-        self.state_builder = make_state_builder(args.state_builder, args)
-
+        # First, do some initial setup and log important information.
         proc = self._setup_proc_and_logger(args)
+
+        # Record the selected state builder in the class attributes
+        self.state_builder = make_state_builder(args.state_builder, args)
 
         # If args.run_start is not none, write validation and prediction
         # data to a pickle later

--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -199,8 +199,11 @@ class SQLStateBuilder(StateBuilder):
 #-------------------------------------------------------------------------------
 class ACISStateBuilder(StateBuilder):
 
-    def __init__(self, interrupt=False, backstop_file=None, nlet_file=None,
-                 verbose=2, logger=None):
+    def __init__(self, interrupt=False, 
+                       backstop_file=None,
+                       nlet_file=None,
+                       outdir = None,
+                       verbose=2, logger=None):
         """
         Give the ACISStateBuilder arguments that were passed in
         from the command line and get the backstop commands from the load
@@ -221,6 +224,7 @@ class ACISStateBuilder(StateBuilder):
         logger : Logger object, optional
             The Python Logger object to be used when logging.
         """
+
         # Import the BackstopHistory class
         from backstop_history import BackstopHistory
 
@@ -230,6 +234,7 @@ class ACISStateBuilder(StateBuilder):
         # Create an instance of the Backstop command History Class
         self.BSC = BackstopHistory.Backstop_History_Class('ACIS-Continuity.txt', 
                                                            self.nlet_file, 
+                                                           outdir,
                                                            verbose)
         super(ACISStateBuilder, self).__init__()
 

--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -428,6 +428,7 @@ def make_state_builder(name, args):
         state_builder = builder_class(interrupt=args.interrupt,
                                       backstop_file=args.backstop_file,
                                       nlet_file=args.nlet_file,
+                                      outdir = args.outdir,
                                       verbose=args.verbose,
                                       logger=mylog)
     else:


### PR DESCRIPTION
## Description
Modification to write the assembled history into the model --outdir directory.

This is in addition to the changes included in the  https://github.com/acisops/acis_thermal_check/pull/41
and https://github.com/acisops/backstop_history/pull/20 PR's in that as of the creation of this PR the others
have not yet been put into production.



## Testing

- [ x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #