### PR TITLE
Temporarily disable the inclusion of gratings moves states

### DIFF
--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -54,8 +54,9 @@ class StateBuilder(object):
         self.logger.info('Getting commanded states between %s - %s' %
                          (start.date, stop.date))
 
-        states = kadi_states.get_states(start, stop, state_keys=STATE_KEYS,
-                                        merge_identical=True)
+        with kadi_states.disable_grating_move_duration():
+            states = kadi_states.get_states(start, stop, state_keys=STATE_KEYS,
+                                            merge_identical=True)
 
         # Set start and end state date/times to match telemetry span.  Extend the
         # state durations by a small amount because of a precision issue converting
@@ -181,9 +182,10 @@ class SQLStateBuilder(StateBuilder):
         # Get the states for available commands, boxed by tbegin / sched_stop.
         # The merge_identical=False is for compatibility with legacy Chandra.cmd_states,
         # but this could probably be set to True.
-        states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
-                                        state_keys=STATE_KEYS,
-                                        merge_identical=False)
+        with kadi_states.disable_grating_move_duration():
+            states = kadi_states.get_states(cmds=cmds, start=tbegin, stop=sched_stop,
+                                            state_keys=STATE_KEYS,
+                                            merge_identical=False)
 
         # Make the column order match legacy Chandra.cmd_states.
         states = states[sorted(states.colnames)]
@@ -315,8 +317,10 @@ class ACISStateBuilder(StateBuilder):
         # from the end of telemetry along with the in-review load backstop
         # commands.
 
-        states = kadi_states.get_states(cmds=bs_cmds, start=tbegin, stop=sched_stop,
-                                        state_keys=STATE_KEYS)
+        with kadi_states.disable_grating_move_duration():
+            states = kadi_states.get_states(cmds=bs_cmds, start=tbegin, 
+                                            stop=sched_stop,
+                                            state_keys=STATE_KEYS)
 
         # Make the column order match legacy Chandra.cmd_states.
         states = states[sorted(states.colnames)]


### PR DESCRIPTION
## Description

Recently, kadi was updated to include grating moves in the gratings states (https://github.com/sot/kadi/pull/210). This changes not only the values of the grating states in the `acis_thermal_check` answer tests (expected) but also the values of the thermal propagation (unexpected, since the ACIS thermal models do not depend on grating state). The differences are very small (~0.1-0.2 degC) but are under investigation (a preliminary hypothesis suggests that the reason is that the JSON model spec files used for testing use `evolve_method = 1`). 

For the time being, this PR disables the inclusion of grating moves states in `acis_thermal_check`, which ensures that the regression tests pass. This is ok from the perspective of operations assuming that the above hypothesis proves correct (since the flight versions of these files use `evolve_method = 2`) and since the actual temperature does not depend on gratings moves. 

The tests and model specification files will be updated to accomodate the new gratings moves states at a date in the near future. 

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
