### PR TITLE
Fix prediction plots 

### DIFF
--- a/acis_thermal_check/utils.py
+++ b/acis_thermal_check/utils.py
@@ -163,11 +163,11 @@ class PlotDate:
         fig.clf()
         ax = fig.add_subplot(1, 1, 1)
         # Plot left y-axis
-        ax.plot_date(xt, y, linestyle='-', linewidth=2,
-                     color=self._color)
+        ax.plot(xt, y, linestyle='-', linewidth=2,
+                color=self._color)
         if yy is not None:
-            ax.plot_date(xt, yy, linestyle='--', linewidth=2,
-                         color=self._color2)
+            ax.plot(xt, yy, linestyle='--', linewidth=2,
+                    color=self._color2)
         if xmin is None:
             xmin = min(xt)
         if xmax is None:
@@ -185,8 +185,8 @@ class PlotDate:
         if x2 is not None and y2 is not None:
             ax2 = ax.twinx()
             xt2 = cxctime2plotdate(x2)
-            ax2.plot_date(xt2, y2, linestyle='-', 
-                          linewidth=2, color="magenta")
+            ax2.plot(xt2, y2, linestyle='-', 
+                     linewidth=2, color="magenta")
             ax2.set_xlim(xmin, xmax)
             if ylim2:
                 ax2.set_ylim(*ylim2)


### PR DESCRIPTION
## Description

PR #46 fixed a warning issued by Matplotlib when:

```pycon
linestyle is redundantly defined by the 'linestyle' keyword argument and the fmt string.
```

However, the `PlotDate` class in `acis_thermal_check` uses [`plot_date`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.plot_date.html), instead of [`plot`](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.plot.html). The former sets `fmt='o'` as the default, so that the result of PR #46 was to create a plot that looks like this:

![](https://cxc.cfa.harvard.edu/acis/DPA_thermPredic/FEB1422/oflsa/1dpamzt.png)

This PR simply switches to `plot` instead of `plot_date`, since the former knows how to handle the `plotdate` time format it is passed and the latter is now discouraged.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
