### PR TITLE
Don't check the OCAT for "hot" ACIS observations if there are no observations (vehicle loads)

### DIFF
--- a/acis_thermal_check/acis_obs.py
+++ b/acis_thermal_check/acis_obs.py
@@ -248,6 +248,10 @@ def find_obsid_intervals(cmd_states, load_start):
     # Now we add the stuff we get from ocat_data
     obsids = [e["obsid"] for e in obsid_interval_list]
     ocat_data = fetch_ocat_data(obsids)
+    # For a vehicle load, or if the connection to the ocat server
+    # fails (rare), we will get no data from the ocat so we only
+    # add this info if we need to. In the case of a failed connection
+    # to the OCAT server, -109 C checks should be done by hand
     if ocat_data is not None:
         ocat_keys = list(ocat_data.keys())
         ocat_keys.remove("obsid")

--- a/acis_thermal_check/acis_obs.py
+++ b/acis_thermal_check/acis_obs.py
@@ -61,6 +61,10 @@ def fetch_ocat_data(obsid_list):
            "determine which observations can go to -109 C. " \
            "Any violations of eligible observations should " \
            "be hand-checked."
+    # If no obsids were found (vehicle-only load) do not bother
+    # with this check
+    if len(obsid_list) == 0:
+        return None
     # The following uses a request call to the obscat which explicitly
     # asks for text formatting so that the output can be ingested into
     # an AstroPy table.


### PR DESCRIPTION
## Description

`acis_thermal_check` performs a check of FP temperature violations against the OBSIDs in the science load. For vehicle-only loads there are no OBSIDs to check. The new-ish `fetch_ocat_data` function queries the OCAT with a list of OBSIDs, to check for observations that can go to -109 C because of a low number of expected counts. 

For vehicle-only loads, the list of OBSIDs passed to `fetch_ocat_data` is empty, but instead of handling this properly, the function queries the OCAT and returns garbage, and `BrokenPipe` errors are returned to screen. 

`acis_thermal_check` appears to proceed normally after this, but to avoid any issue this PR changes the behavior so that the OCAT is not checked if the OBSID list is empty. 

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing