### PR TITLE
Minor doc updates

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,15 +25,15 @@ from datetime import datetime
 
 sys.path.insert(0, os.path.abspath('../../'))
 
-import sphinx_bootstrap_theme
-html_theme = 'bootstrap'
-html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
-
-html_theme_options = dict(
-    bootswatch_theme = "readable",
-    navbar_sidebarrel = False,
-    globaltoc_depth = 2,
-)
+html_theme = 'bootstrap-ska'
+html_theme_options = {
+    'logotext1': 'Ska!' ,
+    'logotext2': 'acis_thermal_check',
+    'logotext3': '',
+    'homepage_url': 'https://cxc.cfa.harvard.edu/acis/acis_thermal_check',
+    'homepage_text': 'ska',
+    'homepage_text_2': 'tools'
+}
 
 # -- General configuration ------------------------------------------------
 
@@ -46,7 +46,8 @@ html_theme_options = dict(
 # ones.
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.viewcode']
+              'sphinx.ext.viewcode',
+              'numpydoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -6,7 +6,8 @@ Installation and Development
 .. note:: 
 
     If all you want to do is run the existing thermal models installed on
-    flight Ska, you can safely ignore this section. 
+    flight Ska or the ACIS ops Ska stack, you can safely ignore this 
+    section. 
 
 This assumes that you have a cloned copy of ``acis_thermal_check`` from
 https://github.com/acisops/acis_thermal_check. To install the package simply 

--- a/doc/source/running_models.rst
+++ b/doc/source/running_models.rst
@@ -7,6 +7,53 @@ Running a Thermal Model with ``acis_thermal_check``
 command line. This section provides a brief description on how to run the 
 models, including what the various options are. 
 
+.. _where-to-run:
+
+Where to Run the Models From
+============================
+
+These models are run from a "Ska" Python stack. It can be one already installed
+or it can be `one you installed yourself <https://github.com/sot/skare3/wiki/Ska3-runtime-environment-for-users>`_.
+
+To run as ``acisdude`` on the HEAD LAN, simply issue the command ``setska`` in
+the terminal. If you want to run as yourself and you do not have this alias, 
+you can set it up in your startup file:
+
+.. code-block:: text
+
+    # for csh/tsch
+
+    alias setska 'eval `/proj/sot/ska3/flight/bin/flt_envs -shell tcsh -ska`'
+
+    # for bash/zsh
+
+    alias setska='eval `/proj/sot/ska3/flight/bin/flt_envs -shell bash -ska`'
+
+The ACIS Ops Ska stack often has versions of ``acis_thermal_check`` that are more
+up-to-date than in flight Ska. To use the ACIS Ops Ska stack as ``acisdude``, issue
+the command ``acisska`` in the terminal. If you want to run as yourself and you 
+do not have this alias, you can set it up in your startup file:
+
+.. code-block:: text
+
+    # for csh/tcsh
+
+    alias acisska 'source /data/acis/mambaforge/etc/profile.d/conda.csh; \
+        setenv SKA /proj/sot/ska; conda activate ska'
+    
+    # for bash
+
+    alias acisska='eval "$(/data/acis/mambaforge/bin/conda shell.bash hook)"; \
+        export SKA=/proj/sot/ska; conda activate ska'
+    
+    # for zsh
+    
+    alias acisska='eval "$(/data/acis/mambaforge/bin/conda shell.zsh hook)"; \
+        export SKA=/proj/sot/ska; conda activate ska’
+
+In either case, all commands (e.g. ``dpa_check``, ``dea_check``, etc.) should 
+be in your path after running one of the two aliases.
+
 Base Command-Line Arguments
 ===========================
 


### PR DESCRIPTION
## Description

This PR updates the documentation for `acis_thermal_check` with two changes. 

1. It adds information on how to set up either flight or ACIS Ops ska for how to 
2. It changes the HTML theme to be the default Ska one

## Interface impacts
New docs build currently at https://cxc.cfa.harvard.edu/acis/acis_thermal_check. 

New setup instructions at https://cxc.cfa.harvard.edu/acis/acis_thermal_check/running_models.html#where-to-run-the-models-from

## Testing
None necessary. 
