### PR TITLE
Use explicit time units in time delta

### DIFF
--- a/acis_thermal_check/state_builder.py
+++ b/acis_thermal_check/state_builder.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pprint import pformat
 
+import astropy.units as u
 import kadi.commands
 import kadi.commands.states as kadi_states
 import numpy as np
@@ -86,7 +87,7 @@ class StateBuilder:
         # to date and back to secs.  (The reference tstop could be just over the
         # 0.001 precision of date and thus cause an out-of-bounds error when
         # interpolating state values).
-        dt = 0.01 / 86400
+        dt = 0.01 * u.second
         states["tstart"][0] = (start - dt).secs
         states["datestart"][0] = (start - dt).date
         states["tstop"][-1] = (stop + dt).secs


### PR DESCRIPTION
## Description

In ska3-prime with astropy 5.2, doing something like `CxoTime("2020:001") + 7` generates a warning. The `7` should now be explicitly labeled as days via `7 * u.day` with `import astropy.units as u`. 

See https://github.com/sot/skare3/issues/1055.

This fixes the warning in this package by using an explicit unit for a time arithmetic operation.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (on HEAD `kady` using ska3-prime Python 3.10)

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Just to be sure, I ran tests to raise an exception for the warning in question.
```
env PYTHONWARNINGS=error:Numerical pytest acis_thermal_check -v
```
