### PR TITLE
Improve logging to screen and run.dat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3.11
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1442,8 +1442,7 @@ class ACISThermalCheck:
             % (self.name, proc["run_time"], proc["run_user"]),
         )
         mylog.info("# acis_thermal_check version = %s", version)
-        if cm_version is not None:
-            mylog.info("# chandra_models version = %s", cm_version)
+        mylog.info("# chandra_models version = %s", cm_version)
         args_out = args.__dict__.copy()
         args_out["outdir"] = str(args.outdir.resolve())
         args_out["model_spec"] = ms_out

--- a/acis_thermal_check/main.py
+++ b/acis_thermal_check/main.py
@@ -1417,7 +1417,6 @@ class ACISThermalCheck:
         model_spec : string
             The path to the thermal model specification.
         """
-        import hashlib
 
         if not args.outdir.exists():
             args.outdir.mkdir(parents=True)
@@ -1436,19 +1435,11 @@ class ACISThermalCheck:
             hist_limit=self.hist_limit,
         )
 
-        if isinstance(model_spec, dict):
-            ms = json.dumps(model_spec, indent=4, sort_keys=True).encode()
-        else:
-            with open(model_spec, "rb") as f:
-                ms = f.read()
-        # Figure out the MD5 sum of the model spec file
-        md5sum = hashlib.md5(ms).hexdigest()
         mylog.info(
             "# %s_check run at %s by %s"
             % (self.name, proc["run_time"], proc["run_user"]),
         )
         mylog.info("# acis_thermal_check version = %s" % version)
-        mylog.info("# model_spec file MD5sum = %s" % md5sum)
         mylog.info("Command line options:\n%s\n" % pformat(args.__dict__))
 
         if args.backstop_file is None:


### PR DESCRIPTION
## Description

This PR improves the logging to screen and to the `run.dat` file that `acis_thermal_check` does at the beginning of its run. Specifically:

* Removes the logging of the MD5 of the model specification to the screen since we don't really use it and this value can be different depending on how one serializes the model spec dict to JSON, even if the model is exactly the same. It adds more confusion than help.
* Instead, if we don't supply a model specification file, log the `chandra_models` version we used to screen. If we do use this one, report `chandra_models` version as `None` and report the full path to the file.
* Report the full path of the `output` directory that we used when printing out the command line options (currently it prints out the `__repr__` of the directory which is a `PosixPath`).

For this sample command:

```
dpa_check --oflsdir=/data/acis/LoadReviews/2023/MAY2223/ofls --out=version_check
```

In the current version of `acis_thermal_check`, we see this:

```
acis_thermal_check: [INFO     ] # dpa_check run at Mon Jul 17 13:50:54 2023 by jzuhone
acis_thermal_check: [INFO     ] # acis_thermal_check version = 4.6.1.dev1+g32570dd
acis_thermal_check: [INFO     ] # model_spec file MD5sum = a363cf6438302298a1436e551719cabd
acis_thermal_check: [INFO     ] Command line options:
{'T_init': None,
 'backstop_file': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'days': 21.0,
 'interrupt': False,
 'model_spec': None,
 'nlet_file': '/data/acis/LoadReviews/NonLoadTrackedEvents.txt',
 'oflsdir': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'outdir': PosixPath('version_check'),
 'pred_only': False,
 'run_start': None,
 'state_builder': 'acis',
 'traceback': True,
 'verbose': 1,
 'version': False}
```

with this PR, we see this:

```
acis_thermal_check: [INFO     ] # dpa_check run at Mon Jul 17 13:49:37 2023 by jzuhone
acis_thermal_check: [INFO     ] # acis_thermal_check version = 4.6.1.dev3+g10bd3d6
acis_thermal_check: [INFO     ] # chandra_models version = 3.48
acis_thermal_check: [INFO     ] Command line options:
{'T_init': None,
 'backstop_file': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'days': 21.0,
 'interrupt': False,
 'model_spec': 'chandra_models v3.48',
 'nlet_file': '/data/acis/LoadReviews/NonLoadTrackedEvents.txt',
 'oflsdir': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'outdir': '/Users/jzuhone/version_check',
 'pred_only': False,
 'run_start': None,
 'state_builder': 'acis',
 'traceback': True,
 'verbose': 1,
 'version': False}
```

If we supply a model specification file like so:

```
dpa_check --oflsdir=/data/acis/LoadReviews/2023/MAY2223/ofls --out=version_check --model-spec=dpa_spec.json
```

In the current version of `acis_thermal_check`, we see this:

```
acis_thermal_check: [INFO     ] # dpa_check run at Mon Jul 17 13:52:34 2023 by jzuhone
acis_thermal_check: [INFO     ] # acis_thermal_check version = 4.6.1.dev1+g32570dd
acis_thermal_check: [INFO     ] # model_spec file MD5sum = 36a01389b6a909f81b4508f7c11a73fb
acis_thermal_check: [INFO     ] Command line options:
{'T_init': None,
 'backstop_file': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'days': 21.0,
 'interrupt': False,
 'model_spec': 'dpa_spec.json',
 'nlet_file': '/data/acis/LoadReviews/NonLoadTrackedEvents.txt',
 'oflsdir': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'outdir': PosixPath('version_check'),
 'pred_only': False,
 'run_start': None,
 'state_builder': 'acis',
 'traceback': True,
 'verbose': 1,
 'version': False}
```

with this PR, we see this:

```
acis_thermal_check: [INFO     ] # dpa_check run at Mon Jul 17 13:53:12 2023 by jzuhone
acis_thermal_check: [INFO     ] # acis_thermal_check version = 4.6.1.dev3+g10bd3d6
acis_thermal_check: [INFO     ] # chandra_models version = None
acis_thermal_check: [INFO     ] Command line options:
{'T_init': None,
 'backstop_file': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'days': 21.0,
 'interrupt': False,
 'model_spec': '/Users/jzuhone/dpa_spec.json',
 'nlet_file': '/data/acis/LoadReviews/NonLoadTrackedEvents.txt',
 'oflsdir': '/data/acis/LoadReviews/2023/MAY2223/ofls',
 'outdir': '/Users/jzuhone/version_check',
 'pred_only': False,
 'run_start': None,
 'state_builder': 'acis',
 'traceback': True,
 'verbose': 1,
 'version': False}
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Changes the visual appearance of the logging to screen and the `run.dat` file, but both of these are currently only human-read.
## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Checked to make sure that different combinations of specifying `model-spec` or not worked correctly. 
